### PR TITLE
bugfix; add sort() to indexer find() method; add _lt_ method to spang…

### DIFF
--- a/mmda/types/annotation.py
+++ b/mmda/types/annotation.py
@@ -87,11 +87,9 @@ class SpanGroup(Annotation):
     type: Optional[str] = None
     box_group: Optional[BoxGroup] = None  # TODO[kylel] - implement default behavior
 
-    # def get_symbols(self) -> str:
-    #     if self.text is not None:
-    #         return self.text
-    #     else:
-    #         return ' '.join([self.doc.symbols[span.start:span.end] for span in self.spans])    
+    @property
+    def symbols(self) -> List[str]:
+        return [self.doc.symbols[span.start : span.end] for span in self.spans]
 
     def to_json(self) -> Dict:
         span_group_dict = dict(

--- a/mmda/types/annotation.py
+++ b/mmda/types/annotation.py
@@ -89,7 +89,7 @@ class SpanGroup(Annotation):
 
     @property
     def symbols(self) -> List[str]:
-        return [self.doc.symbols[span.start : span.end] for span in self.spans]
+        return [self.doc._symbols[span.start : span.end] for span in self.spans]
 
     def to_json(self) -> Dict:
         span_group_dict = dict(

--- a/mmda/types/document.py
+++ b/mmda/types/document.py
@@ -12,7 +12,8 @@ import os
 from glob import glob
 
 from mmda.types.image import Image
-from mmda.types.annotation import Annotation, SpanGroup, Indexer, SpanGroupIndexer
+from mmda.types.annotation import Annotation, SpanGroup
+from mmda.types.indexers import Indexer, SpanGroupIndexer
 from mmda.types.names import Symbols, Images
 from mmda.types.image import Image as DocImage
 

--- a/mmda/types/document.py
+++ b/mmda/types/document.py
@@ -27,7 +27,7 @@ class Document:
         symbols: str,
         images: Optional[List["Image.Image"]] = None,
     ):
-        self.symbols = symbols
+        self._symbols = symbols
         self.images = images
         self._fields = []
         self._indexers: Dict[str, Indexer] = {}
@@ -110,7 +110,7 @@ class Document:
                 field2: [...]
             }
         """
-        doc_dict = {Symbols: self.symbols}
+        doc_dict = {Symbols: self._symbols}
         if with_images:
             doc_dict[Images] = [image.to_json() for image in self.images]
 

--- a/mmda/types/indexers.py
+++ b/mmda/types/indexers.py
@@ -1,0 +1,49 @@
+"""
+
+Indexes for Annotations
+
+"""
+
+from typing import List
+
+from abc import abstractmethod
+from dataclasses import dataclass, field
+
+from intervaltree import IntervalTree
+from mmda.types.annotation import SpanGroup, Annotation
+
+
+@dataclass
+class Indexer:
+    """Stores an index for a particular collection of Annotations.
+    Indexes in this library focus on *INTERSECT* relations."""
+
+    @abstractmethod
+    def find(self, query: Annotation) -> List[Annotation]:
+        """Returns all matching Annotations given a suitable query"""
+
+
+@dataclass
+class SpanGroupIndexer(Indexer):
+
+    # careful; if write it as _index = IntervalTree(), all SpanGroupIndexers will share the same _index object
+    _index: IntervalTree = field(default_factory=IntervalTree)
+
+    # TODO[kylel] - maybe have more nullable args for different types of queryes (just start/end ints, just SpanGroup)
+    def find(self, query: SpanGroup) -> List[SpanGroup]:
+        if not isinstance(query, SpanGroup):
+            raise ValueError(f'SpanGroupIndexer only works with `query` that is SpanGroup type')
+
+        all_matched_span_groups = []
+        for span in query.spans:
+            for matched_span_group in self._index[span.start : span.end]:
+                if matched_span_group.data not in all_matched_span_groups: # Deduplicate
+                    all_matched_span_groups.append(matched_span_group.data)
+        # retrieval can be out of order, so sort
+        return sorted(all_matched_span_groups)
+
+    def __getitem__(self, key):
+        return self._index[key]
+
+    def __setitem__(self, key, value):
+        self._index[key] = value

--- a/mmda/types/span.py
+++ b/mmda/types/span.py
@@ -31,3 +31,9 @@ class Span:
         else:
             box = None
         return Span(start=span_dict['start'], end=span_dict['end'], box=box)
+
+    def __lt__(self, other: 'Span'):
+        if self.id and other.id:
+            return self.id < other.id
+        else:
+            return self.start < other.start


### PR DESCRIPTION
bugfix for indexer
1. add sort() to indexer find() method because interval tree returns a set, not list
2. add _lt_ method to spangroups and span
3. move indexer to its own file

also some nice quality fixes
1. document's symbols are hidden method now
2. added a symbols property to SpanGroup to make easier indexing into document for strings