### PR TITLE
[fix] Return relative coordinates in LP predictor

### DIFF
--- a/examples/vila_for_scidoc_parsing/README.md
+++ b/examples/vila_for_scidoc_parsing/README.md
@@ -4,7 +4,7 @@
 
 1. Install the necessary python dependencies
     ```bash
-    pip install mmda
+    pip install mmda # alternatively, you can pip install ../ -e
     pip install -r requirements.txt
     ```
 2. Install poppler for rendering PDF images
@@ -23,9 +23,3 @@ python main.py --pdf-path <path-to-pdf-files> \
 It will run PubLayNet-based layout detection models to identify the layout structure, and run
 VILA models based on the detected layouts to perform token classification. All detected layouts
 and token categories will visualized and stored in the export-folder.
-
-## Known Limitation 
-
-This script uses the pdfplumber PDF parser which is used during the training of the VILA models. 
-The parsed PDF tokens and layout detection boxes are in absolute coordinates, which is incompatible 
-with the relative coordinates used in the ssparser implementation in the current `mmda` library.

--- a/examples/vila_for_scidoc_parsing/README.md
+++ b/examples/vila_for_scidoc_parsing/README.md
@@ -23,3 +23,8 @@ python main.py --pdf-path <path-to-pdf-files> \
 It will run PubLayNet-based layout detection models to identify the layout structure, and run
 VILA models based on the detected layouts to perform token classification. All detected layouts
 and token categories will visualized and stored in the export-folder.
+
+If you see an error reading `SSL:CERTIFICATE_VERIFY_FAILED`, then you may need 
+to download a certificate for Python. See [this Stack Overflow 
+answer](https://stackoverflow.com/a/53310545/2096369) for a fix that might work 
+on Mac, as well as other answers.

--- a/examples/vila_for_scidoc_parsing/README.md
+++ b/examples/vila_for_scidoc_parsing/README.md
@@ -1,5 +1,7 @@
 # Use VILA for Scientific Documents Parsing
 
+All the command are executed in this folder `examples/vila_for_scidoc_parsing`.
+
 ## Installation 
 
 1. Install the necessary python dependencies
@@ -7,7 +9,12 @@
     pip install mmda # alternatively, you can pip install ../ -e
     pip install -r requirements.txt
     ```
-2. Install poppler for rendering PDF images
+2. Install poppler for rendering PDF images - the installation methods are different based on your platform:
+
+    - Mac: brew install poppler
+    - Ubuntu: sudo apt-get install -y poppler-utils
+    - Windows: See [this post](https://stackoverflow.com/questions/18381713/how-to-install-poppler-on-windows)
+
 3. Download the VILA models
 
     For now, please contact @shannons for downloading the weights. 
@@ -19,7 +26,10 @@ python main.py --pdf-path <path-to-pdf-files> \
                --vila-type <hvila-or-vila> \
                --vila-model-path <path-to-vila-models> \
                --export-folder <the-folder-for-saving-visualizations>
+# By default, you could just run 
+# python main.py --pdf-path <path-to-pdf-files>
 ```
+
 It will run PubLayNet-based layout detection models to identify the layout structure, and run
 VILA models based on the detected layouts to perform token classification. All detected layouts
 and token categories will visualized and stored in the export-folder.

--- a/examples/vila_for_scidoc_parsing/main.py
+++ b/examples/vila_for_scidoc_parsing/main.py
@@ -1,23 +1,16 @@
-from collections import defaultdict
+from typing import List
 import argparse
 from copy import copy
 import os
 
 from tqdm import tqdm
 import layoutparser as lp
-from vila.pdftools.pdf_extractor import PDFExtractor
 
-from mmda.parsers.symbol_scraper_parser import SymbolScraperParser
-from mmda.types.document import Document
-from mmda.types.box import Box
-from mmda.types.span import Span
+from mmda.parsers.pdfplumber_parser import PDFPlumberParser
 from mmda.types.annotation import SpanGroup
 from mmda.predictors.lp_predictors import LayoutParserPredictor
 from mmda.predictors.hf_predictors.vila_predictor import IVILAPredictor, HVILAPredictor
 
-
-ssparser = SymbolScraperParser(sscraper_bin_path="")  # A dummy ssparser
-pdf_extractor = PDFExtractor("pdfplumber")
 
 DOCBANK_LABEL_MAP = {
     "0": "paragraph",
@@ -37,18 +30,23 @@ DOCBANK_LABEL_MAP = {
 DOCBANK_LABEL_MAP = {int(key): val for key, val in DOCBANK_LABEL_MAP.items()}
 
 
-def _coordinates(box, canvas_width, canvas_height):
-    return lp.Rectangle(box.l, box.t, (box.l + box.w), (box.t + box.h))
-
-
 def draw_tokens(
-    image, doc_tokens, color_map=None, token_boundary_width=0, alpha=0.25, **kwargs
+    image,
+    doc_tokens: List[SpanGroup],
+    color_map=None,
+    token_boundary_width=0,
+    alpha=0.25,
+    **kwargs,
 ):
 
     w, h = image.size
     layout = [
         lp.TextBlock(
-            _coordinates(token.spans[0].box, w, h),
+            lp.Rectangle(
+                *token.spans[0]
+                .box.get_absolute(page_height=h, page_width=w)
+                .coordinates
+            ),
             type=token.type,
             text=token.symbols[0],
         )
@@ -60,18 +58,27 @@ def draw_tokens(
         color_map=color_map,
         box_width=token_boundary_width,
         box_alpha=alpha,
-        **kwargs
+        **kwargs,
     )
 
 
 def draw_blocks(
-    image, doc_tokens, color_map=None, token_boundary_width=0, alpha=0.25, **kwargs
+    image,
+    doc_tokens: List[SpanGroup],
+    color_map=None,
+    token_boundary_width=0,
+    alpha=0.25,
+    **kwargs,
 ):
 
     w, h = image.size
     layout = [
         lp.TextBlock(
-            _coordinates(token.box_group.boxes[0], w, h),
+            lp.Rectangle(
+                *token.box_group.boxes[0]
+                .get_absolute(page_height=h, page_width=w)
+                .coordinates
+            ),
             type=token.box_group.type,
             text=token.symbols[0],
         )
@@ -83,50 +90,8 @@ def draw_blocks(
         color_map=color_map,
         box_width=token_boundary_width,
         box_alpha=alpha,
-        **kwargs
+        **kwargs,
     )
-
-
-def to_Box(textblock, page_id, page_with, page_height):
-    block = textblock.block
-    return Box(block.x_1, block.y_1, block.width, block.height, page_id)
-
-
-def convert_to_doc_object(pdf_tokens, pdf_images=None):
-
-    page_to_row_to_tokens = defaultdict(lambda: defaultdict(list))
-
-    for page_id, page_tokens in enumerate(pdf_tokens):
-        for line_id, line_tokens in enumerate(page_tokens.get_text_segments()):
-            for token_id, token in enumerate(line_tokens):
-                page_to_row_to_tokens[page_id][line_id].append(
-                    {
-                        "text": token.text,
-                        "bbox": to_Box(
-                            token, page_id, page_tokens.width, page_tokens.height
-                        ),
-                    }
-                )
-
-    doc_dict = ssparser._convert_nested_text_to_doc_json(
-        {
-            page: {row: tokens for row, tokens in row_to_tokens.items()}
-            for page, row_to_tokens in page_to_row_to_tokens.items()
-        }
-    )
-
-    doc = Document.from_json(doc_dict=doc_dict)
-    if pdf_images is not None:
-        doc.images = pdf_images
-    return doc
-
-
-def load_pdf(path_to_pdf):
-    pdf_tokens, pdf_images = pdf_extractor.load_tokens_and_image(
-        path_to_pdf,
-    )
-    doc = convert_to_doc_object(pdf_tokens, pdf_images)
-    return doc
 
 
 if __name__ == "__main__":
@@ -144,7 +109,7 @@ if __name__ == "__main__":
         type=str,
         default="pdf-predictions",
     )
-    
+
     args = parser.parse_args()
 
     if args.vila_type == "ivila":
@@ -164,15 +129,22 @@ if __name__ == "__main__":
     equation_layout_predictor = LayoutParserPredictor.from_pretrained(
         "lp://efficientdet/MFD"
     )
-    
+
+    pdfplumber_parser = PDFPlumberParser()
+
     pbar = tqdm(args.pdf_path)
     for pdf_path in pbar:
         pbar.set_description(f"Working on {pdf_path}")
-        doc = load_pdf(pdf_path)
+
+        doc = pdfplumber_parser.parse(input_pdf_path=pdf_path, load_images=True)
 
         # Obtaining Layout Predictions
-        layout_regions = layout_predictor.predict(doc) # Detect content regions like paragraphs
-        equation_layout_regions = equation_layout_predictor.predict(doc) # Detect equation regions 
+        layout_regions = layout_predictor.predict(
+            doc
+        )  # Detect content regions like paragraphs
+        equation_layout_regions = equation_layout_predictor.predict(
+            doc
+        )  # Detect equation regions
 
         doc.annotate(blocks=layout_regions + equation_layout_regions)
 
@@ -180,20 +152,20 @@ if __name__ == "__main__":
         spans = vila_predictor.predict(doc)
         doc.annotate(preds=spans)
 
-        save_folder = os.path.join(args.export_folder, os.path.basename(pdf_path).split(".")[0])
-        os.makedirs(save_folder)
+        save_folder = os.path.join(
+            args.export_folder, os.path.basename(pdf_path).rstrip(".pdf")
+        )
+        os.makedirs(save_folder, exist_ok=True)
 
         for pid in range(len(doc.pages)):
-            
+
             new_tokens = []
             for pred in doc.pages[pid].preds:
                 for token in pred.tokens:
                     _token = copy(token)
                     _token.type = DOCBANK_LABEL_MAP[pred.type]
-                    new_tokens.append(
-                        _token
-                    )
-                    
+                    new_tokens.append(_token)
+
             viz = draw_blocks(doc.images[pid], doc.pages[pid].blocks, alpha=0)
             viz = draw_tokens(viz, new_tokens, alpha=0.6)
 

--- a/examples/vila_for_scidoc_parsing/requirements.txt
+++ b/examples/vila_for_scidoc_parsing/requirements.txt
@@ -1,1 +1,3 @@
 layoutparser[effdet]>=0.3.0
+transformers
+vila

--- a/examples/vila_for_scidoc_parsing/requirements.txt
+++ b/examples/vila_for_scidoc_parsing/requirements.txt
@@ -1,2 +1,1 @@
-vila
 layoutparser[effdet]>=0.3.0

--- a/mmda/predictors/hf_predictors/vila_predictor.py
+++ b/mmda/predictors/hf_predictors/vila_predictor.py
@@ -145,8 +145,16 @@ class BaseVILAPredictor(BaseHFPredictor):
     def predict(self, document: Document) -> List[Annotation]:
 
         page_prediction_results = []
-        for page in tqdm(document.pages):
-            pdf_dict = convert_document_page_to_pdf_dict(page)
+        for page_id, page in enumerate(tqdm(document.pages)):
+
+            page_width, page_height = document.images[page_id].size
+
+            pdf_dict = convert_document_page_to_pdf_dict(
+                page, page_width=page_width, page_height=page_height
+            ) 
+            # VILA models trained based on absolute page width rather than the 
+            # size (1000, 1000) in vanilla LayoutLM models 
+            
             model_inputs = self.preprocess(pdf_dict)
             model_outputs = self.model(**self.model_input_collator(model_inputs))
             model_predictions = self.get_category_prediction(model_outputs)

--- a/mmda/predictors/lp_predictors.py
+++ b/mmda/predictors/lp_predictors.py
@@ -20,7 +20,7 @@ class LayoutParserPredictor(BasePredictor):
     @classmethod
     def from_pretrained(
         cls,
-        config_path: str = 'lp://PrimaLayout/mask_rcnn_R_50_FPN_3x/config',
+        config_path: str = "lp://efficientdet/PubLayNet",
         model_path: str = None,
         label_map: Optional[Dict] = None,
         extra_config: Optional[Dict] = None,
@@ -33,41 +33,78 @@ class LayoutParserPredictor(BasePredictor):
         and will be updated in the future.
         """
 
-        # TODO[shannon]: In the current version of layoutparser (v0.2.0),
-        # only Detectron2 models loaded. And we will modify it in the future
-        # such that we can load models using different DL backends.
-
         model = lp.AutoLayoutModel(
-            config_path = config_path,
-            model_path = model_path,
-            label_map = label_map,
-            extra_config = extra_config,
-            device = device,
+            config_path=config_path,
+            model_path=model_path,
+            label_map=label_map,
+            extra_config=extra_config,
+            device=device,
         )
 
         return cls(model)
 
-    def postprocess(self, model_outputs: lp.Layout, page_index: int) -> List[BoxGroup]:
-        """Convert the model outputs into the Annotation format"""
+    def postprocess(self, 
+        model_outputs: lp.Layout, 
+        page_index: int,
+        image: "PIL.Image") -> List[BoxGroup]:
+        """Convert the model outputs into the mmda format
+
+        Args:
+            model_outputs (lp.Layout): 
+                The layout detection results from layoutparser for 
+                a page image
+            page_index (int): 
+                The index of the current page, used for creating the 
+                `Box` object
+            image (PIL.Image): 
+                The image of the current page, used for converting
+                to relative coordinates for the box objects
+
+        Returns:
+            List[BoxGroup]: 
+            The detected layout stored in the BoxGroup format.
+        """
 
         # block.coordinates returns the left, top, bottom, right coordinates
+
+        page_width, page_height = image.size
+
         return [
-            BoxGroup(boxes = [Box(
-                l=block.coordinates[0],
-                t=block.coordinates[1],
-                w=block.width,
-                h=block.height,
-                page=page_index,
-            )], type = block.type)
+            BoxGroup(
+                boxes=[
+                    Box(
+                        l=block.coordinates[0],
+                        t=block.coordinates[1],
+                        w=block.width,
+                        h=block.height,
+                        page=page_index,
+                    ).get_relative(
+                        page_width=page_width,
+                        page_height=page_height,
+                    )
+                ],
+                type=block.type,
+            )
             for block in model_outputs
         ]
 
-    def predict(self, document: Document) -> List[Annotation]:
+    def predict(self, document: Document) -> List[BoxGroup]:
+        """Returns a list of Boxgroups for the detected layouts for all pages
 
+        Args:
+            document (Document): 
+                The input document object 
+
+        Returns:
+            List[BoxGroup]: 
+                The returned Boxgroups for the detected layouts for all pages
+        """
         document_prediction = []
 
         for image_index, image in enumerate(tqdm(document.images)):
             model_outputs = self.model.detect(image)
-            document_prediction.extend(self.postprocess(model_outputs, image_index))
+            document_prediction.extend(
+                self.postprocess(model_outputs, image_index, image)
+            )
 
         return document_prediction

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 import setuptools
 
 setuptools.setup(
-    name='mmda',
-    version='0.0.2',
-    python_requires=">= 3.8",
+    name="mmda",
+    version="0.0.2",
+    python_requires=">= 3.7",
     packages=setuptools.find_packages(include=["mmda.*"]),
-    install_requires=['intervaltree', 'pdf2image'],
-    extras_require={"dev": ["pytest"]}
+    install_requires=["intervaltree", "pdf2image", "pdfplumber"],
+    extras_require={"dev": ["pytest"]},
 )


### PR DESCRIPTION
Previously, LP predictor returns the absolute coordinates, which is incompatible with the rest of the library. In this update, 
1. LP predictor returns the relative coordinates
2. Fix the coordinate conversion for VILA models 
3. Update the VILA example to incorporate main mmda updates 