### PR TITLE
Use Grobid header API method to get title/abstract

### DIFF
--- a/mmda/parsers/grobid_parser.py
+++ b/mmda/parsers/grobid_parser.py
@@ -1,0 +1,100 @@
+import io
+import xml.etree.ElementTree as et
+
+import requests
+from mmda.parsers.parser import Parser
+from mmda.types.annotation import SpanGroup
+from mmda.types.document import Document
+from mmda.types.names import Symbols
+from mmda.types.span import Span
+
+DEFAULT_API = "http://localhost:8070/api/processHeaderDocument"
+NS = {"tei": "http://www.tei-c.org/ns/1.0"}
+
+
+def _get_token_spans(text: str, tokens: list[str], offset: int = 0) -> list[int]:
+    assert len(text) > 0
+    assert len(tokens) > 0
+    assert offset >= 0
+
+    spans = [Span(start=offset, end=len(tokens[0]) + offset)]
+
+    for i, token in enumerate(tokens):
+        if i == 0:
+            continue
+
+        start = text.find(token, spans[-1].end - offset, len(text))
+        end = start + len(token)
+
+        spans.append(Span(start=start + offset, end=end + offset))
+
+    return spans
+
+
+def _post_document(url: str, input_pdf_path: str) -> str:
+    req = requests.post(url, files={"input": open(input_pdf_path, "rb")})
+
+    if req.status_code != 200:
+        raise RuntimeError(f"Unable to process document: {input_pdf_path}!")
+
+    return req.text
+
+
+class GrobidHeaderParser(Parser):
+    """Grobid parser that uses header API methods to get title and abstract only. The
+    current purpose of this class is evaluation against other methods for title and
+    abstract extraction from a PDF.
+    """
+
+    _url: str
+
+    def __init__(self, url: str = DEFAULT_API) -> None:
+        self._url = url
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+    def parse(self, input_pdf_path: str) -> Document:
+        xml = _post_document(self.url, input_pdf_path)
+        root = et.parse(io.StringIO(xml)).getroot()
+
+        title = self._get_title(root)
+        if len(title.text) == 0:
+            raise RuntimeError(f"Unable to extract title: {input_pdf_path}!")
+
+        abstract = self._get_abstract(root, offset=len(title.text) + 1)
+        if len(abstract.text) == 0:
+            raise RuntimeError(f"Unable to extract abstract: {input_pdf_path}!")
+
+        symbols = "\n".join([title.text, abstract.text])
+
+        document = Document(symbols=symbols)
+        document.annotate(title=[title], abstract=[abstract])
+
+        return document
+
+    def _get_title(self, root: et.Element) -> SpanGroup:
+        matches = root.findall(".//tei:titleStmt/tei:title", NS)
+
+        if len(matches) == 0:
+            return []
+
+        text = matches[0].text.strip()
+        tokens = text.split()
+        spans = _get_token_spans(text, tokens)
+
+        return SpanGroup(spans=spans, text=text)
+
+    def _get_abstract(self, root: et.Element, offset: int) -> SpanGroup:
+        matches = root.findall(".//tei:profileDesc//tei:abstract//", NS)
+
+        if len(matches) == 0:
+            return []
+
+        # An abstract may have many paragraphs
+        text = "\n".join(m.text for m in matches)
+        tokens = text.split()
+        spans = _get_token_spans(text, tokens, offset=offset)
+
+        return SpanGroup(spans=spans, text=text)

--- a/mmda/parsers/parser.py
+++ b/mmda/parsers/parser.py
@@ -6,11 +6,24 @@ Dataclass for creating token streams from a document
 
 """
 
-from typing import Optional, Union, List
 from abc import abstractmethod
+from typing import List, Optional, Protocol, Union
 
 from mmda.types.document import Document
 from mmda.types.image import load_pdf_images_from_path
+
+
+class Parser(Protocol):
+    @abstractmethod
+    def parse(self, input_pdf_path: str, **kwargs) -> Document:
+        """Given an input PDF return a Document with at least symbols
+
+        Args:
+            input_pdf_path (str): Path to the input PDF to process
+
+        Returns:
+            Document: Depending on parser support at least symbols in the PDF
+        """
 
 
 class BaseParser:

--- a/tests/fixtures/grobid-tei-maml-header.xml
+++ b/tests/fixtures/grobid-tei-maml-header.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xml:space="preserve" xmlns="http://www.tei-c.org/ns/1.0" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.tei-c.org/ns/1.0 https://raw.githubusercontent.com/kermitt2/grobid/master/grobid-home/schemas/xsd/Grobid.xsd"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+	<teiHeader xml:lang="en">
+		<fileDesc>
+			<titleStmt>
+				<title level="a" type="main">Model-Agnostic Meta-Learning for Fast Adaptation of Deep Networks</title>
+			</titleStmt>
+			<publicationStmt>
+				<publisher/>
+				<availability status="unknown"><licence/></availability>
+			</publicationStmt>
+			<sourceDesc>
+				<biblStruct>
+					<analytic>
+						<author>
+							<persName><forename type="first">Chelsea</forename><surname>Finn</surname></persName>
+						</author>
+						<author>
+							<persName><forename type="first">Pieter</forename><surname>Abbeel</surname></persName>
+						</author>
+						<author>
+							<persName><forename type="first">Sergey</forename><surname>Levine</surname></persName>
+						</author>
+						<title level="a" type="main">Model-Agnostic Meta-Learning for Fast Adaptation of Deep Networks</title>
+					</analytic>
+					<monogr>
+						<imprint>
+							<date/>
+						</imprint>
+					</monogr>
+					<idno type="MD5">6F05654C8B9A8480AB2785F883473C08</idno>
+				</biblStruct>
+			</sourceDesc>
+		</fileDesc>
+		<encodingDesc>
+			<appInfo>
+				<application version="0.7.0" ident="GROBID" when="2021-09-28T21:25+0000">
+					<desc>GROBID - A machine learning software for extracting information from scholarly documents</desc>
+					<ref target="https://github.com/kermitt2/grobid"/>
+				</application>
+			</appInfo>
+		</encodingDesc>
+		<profileDesc>
+			<abstract>
+				<p>We propose an algorithm for meta-learning that is model-agnostic, in the sense that it is compatible with any model trained with gradient descent and applicable to a variety of different learning problems, including classification, regression, and reinforcement learning. The goal of meta-learning is to train a model on a variety of learning tasks, such that it can solve new learning tasks using only a small number of training samples. In our approach, the parameters of the model are explicitly trained such that a small number of gradient steps with a small amount of training data from a new task will produce good generalization performance on that task. In effect, our method trains the model to be easy to fine-tune. We demonstrate that this approach leads to state-of-the-art performance on two fewshot image classification benchmarks, produces good results on few-shot regression, and accelerates fine-tuning for policy gradient reinforcement learning with neural network policies.</p>
+			</abstract>
+		</profileDesc>
+	</teiHeader>
+	<text xml:lang="en">
+	</text>
+</TEI>

--- a/tests/test_parsers/test_grobid_header_parser.py
+++ b/tests/test_parsers/test_grobid_header_parser.py
@@ -1,0 +1,54 @@
+import unittest
+import unittest.mock as um
+
+import pytest
+from mmda.parsers.grobid_parser import GrobidHeaderParser
+
+XML_OK = open("tests/fixtures/grobid-tei-maml-header.xml", "r").read()
+
+
+def mock_post(*args, **kwargs):
+    class MockResponse:
+        def __init__(self, xml: str, status_code: int) -> None:
+            self._xml = xml
+            self._status_code = status_code
+
+        @property
+        def text(self):
+            return self._xml
+
+        @property
+        def status_code(self):
+            return self._status_code
+
+    if args[0].endswith("ok"):
+        return MockResponse(XML_OK, 200)
+    elif args[0].endswith("err"):
+        return MockResponse(None, 500)
+
+    return MockResponse(None, 404)
+
+
+class TestGrobidHeaderParser(unittest.TestCase):
+    @um.patch("requests.post", side_effect=mock_post)
+    def test_processes_header(self, mock_post):
+        parser = GrobidHeaderParser(url="http://localhost/ok")
+
+        with um.patch("builtins.open", um.mock_open(read_data="it's xml")):
+            document = parser.parse(input_pdf_path="some-location")
+
+        assert document.title[0].text.startswith("Model-Agnostic Meta-Learning")
+        assert document.abstract[0].text.startswith("We propose an algorithm")
+
+        assert document.title[0].symbols[0:2] == ["Model-Agnostic", "Meta-Learning"]
+        assert document.abstract[0].symbols[0:2] == ["We", "propose"]
+
+    @um.patch("requests.post", side_effect=mock_post)
+    def test_processes_header_server_error_raises(self, mock_post):
+        parser = GrobidHeaderParser(url="http://localhost/err")
+
+        with pytest.raises(RuntimeError) as ex:
+            with um.patch("builtins.open", um.mock_open(read_data="it's xml")):
+                parser.parse(input_pdf_path="some-location")
+
+        assert "Unable to process" in str(ex.value)


### PR DESCRIPTION
Basic "parser" that posts a PDF to a remote (or localhost) Grobid instance. The header parser provided here only requests header information and also provides title and abstract annotations. 

I've introduced a Parser protocol because I believe this makes more sense than a base class that already has conflicts in passed parameters. For example, Grobid doesn't care about any DPI setting.

If some parsers share base functionality then they can have a parent class that exists at a non-root level. Eventually BaseParser should be removed.