### PR TITLE
[wip] Move PDF->Image functionality *out* of Parser into Rasterizer

### DIFF
--- a/mmda/parsers/grobid_parser.py
+++ b/mmda/parsers/grobid_parser.py
@@ -69,9 +69,7 @@ class GrobidHeaderParser(Parser):
     def url(self) -> str:
         return self._url
 
-    def parse(self, input_pdf_path: str,
-              output_json_path: Optional[str] = None,
-              tempdir: Optional[str] = None) -> Document:
+    def parse(self, input_pdf_path: str, tempdir: Optional[str] = None) -> Document:
 
         xml = _post_document(url=self.url, input_pdf_path=input_pdf_path)
 
@@ -82,12 +80,6 @@ class GrobidHeaderParser(Parser):
                 f_out.write(xml)
 
         doc: Document = self._parse_xml_to_doc(xml=xml)
-
-        # TODO: remove `indent=4` for storage efficiency
-        if output_json_path:
-            with open(output_json_path, 'w') as f_out:
-                json.dump(doc.to_json(), f_out, indent=4)
-
         return doc
 
     def _parse_xml_to_doc(self, xml: str) -> Document:

--- a/mmda/parsers/parser.py
+++ b/mmda/parsers/parser.py
@@ -10,7 +10,6 @@ from abc import abstractmethod
 from typing import List, Optional, Protocol, Union
 
 from mmda.types.document import Document
-from mmda.types.image import load_pdf_images_from_path
 
 
 class Parser(Protocol):

--- a/mmda/parsers/parser.py
+++ b/mmda/parsers/parser.py
@@ -23,6 +23,7 @@ class Parser(Protocol):
 
         Args:
             input_pdf_path (str): Path to the input PDF to process
+            output_json_path (str):  Optional path to the output JSON file
 
         Returns:
             Document: Depending on parser support at least symbols in the PDF

--- a/mmda/parsers/parser.py
+++ b/mmda/parsers/parser.py
@@ -14,15 +14,11 @@ from mmda.types.document import Document
 
 class Parser(Protocol):
     @abstractmethod
-    def parse(self,
-              input_pdf_path: str,
-              output_json_path: Optional[str] = None,
-              **kwargs) -> Document:
+    def parse(self, input_pdf_path: str, **kwargs) -> Document:
         """Given an input PDF return a Document with at least symbols
 
         Args:
             input_pdf_path (str): Path to the input PDF to process
-            output_json_path (str):  Optional path to the output JSON file
 
         Returns:
             Document: Depending on parser support at least symbols in the PDF

--- a/mmda/parsers/parser.py
+++ b/mmda/parsers/parser.py
@@ -15,7 +15,10 @@ from mmda.types.image import load_pdf_images_from_path
 
 class Parser(Protocol):
     @abstractmethod
-    def parse(self, input_pdf_path: str, **kwargs) -> Document:
+    def parse(self,
+              input_pdf_path: str,
+              output_json_path: Optional[str] = None,
+              **kwargs) -> Document:
         """Given an input PDF return a Document with at least symbols
 
         Args:
@@ -24,48 +27,3 @@ class Parser(Protocol):
         Returns:
             Document: Depending on parser support at least symbols in the PDF
         """
-
-
-class BaseParser:
-
-    DEFAULT_PDF_RENDERING_DPI = 72
-
-    def __init__(self, dpi: int = None) -> None:
-        """
-        dpi (int, optional):
-            Used for specify the resolution (or `DPI, dots per inch
-            <https://en.wikipedia.org/wiki/Dots_per_inch>`_) when loading images of
-            the pdf. Higher DPI values mean clearer images (also larger file sizes).
-
-            Defaults to `self.DEFAULT_PDF_RENDERING_DPI=72`.
-        """
-
-    @property
-    def dpi(self) -> int:
-        return self._dpi
-
-    @dpi.setter
-    def dpi(self, dpi: int):
-        self._dpi = dpi if dpi is not None else self.DEFAULT_PDF_RENDERING_DPI
-
-    @abstractmethod
-    def parse(
-        self,
-        input_pdf_path: str,
-        output_json_path: Optional[str] = None,
-        tempdir: Optional[str] = None,
-        load_images: bool = False,
-    ) -> Union[str, Document]:
-        """This is the main entrance point for using the PDF parsers. For a
-        given PDF file, this method will return a Document object.
-        """
-
-    # TODO[kylel] - serialization?
-    def load_images(self, input_pdf_path: str, dpi=None) -> List["PIL.Image"]:
-        if dpi is None:
-            dpi = self.dpi
-        else:
-            self.dpi = dpi
-        images = load_pdf_images_from_path(input_pdf_path, dpi=dpi)
-        # Though 72 is not the default dpi for pdf2image, it's commonly used by other PDF parsing systems
-        return images

--- a/mmda/parsers/pdfplumber_parser.py
+++ b/mmda/parsers/pdfplumber_parser.py
@@ -9,7 +9,7 @@ from mmda.types.span import Span
 from mmda.types.box import Box
 from mmda.types.annotation import SpanGroup
 from mmda.types.document import Document
-from mmda.parsers.parser import BaseParser
+from mmda.parsers.parser import Parser
 from mmda.types.names import *
 
 
@@ -66,7 +66,7 @@ def simple_line_detection(
     return lines
 
 
-class PDFPlumberParser(BaseParser):
+class PDFPlumberParser(Parser):
     def __init__(
         self,
         token_x_tolerance: int = 1.5,

--- a/mmda/parsers/pdfplumber_parser.py
+++ b/mmda/parsers/pdfplumber_parser.py
@@ -154,23 +154,8 @@ class PDFPlumberParser(Parser):
         )
         self.dpi = dpi
 
-    def parse(
-        self,
-        input_pdf_path: str,
-        output_json_path: Optional[str] = None,
-        load_images=False,
-    ) -> Document:
-
+    def parse(self, input_pdf_path: str) -> Document:
         doc = self._load_pdf_as_doc(input_pdf_path)
-
-        if load_images:
-            doc.images = self.load_images(input_pdf_path)
-
-        # TODO: remove `indent=4` for storage efficiency
-        if output_json_path:
-            with open(output_json_path, "w") as f_out:
-                json.dump(doc.to_json(), f_out, indent=4)
-
         return doc
 
     def _load_page_tokens(

--- a/mmda/parsers/symbol_scraper_api.py
+++ b/mmda/parsers/symbol_scraper_api.py
@@ -15,8 +15,9 @@ def parse_pdf():
         pdf_path = f"{tempdir}/input.pdf"
         with open(pdf_path, "wb") as f:
             f.write(request.get_data())
-        doc = sscraper.parse(pdf_path, load_images=True)
-        return doc.to_json(with_images=True)
+        doc = sscraper.parse(pdf_path)
+        # TODO: add image stuff here
+        return doc.to_json()
 
 if __name__ == "__main__":
     port = int(os.getenv("PORT", "8080"))

--- a/mmda/parsers/symbol_scraper_parser.py
+++ b/mmda/parsers/symbol_scraper_parser.py
@@ -28,8 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 class SymbolScraperParser(Parser):
-    def __init__(self, sscraper_bin_path: str, dpi:int = None):
-        self.dpi = dpi
+    def __init__(self, sscraper_bin_path: str):
         self.sscraper_bin_path = sscraper_bin_path
 
     def parse(self, input_pdf_path: str, tempdir: Optional[str] = None) -> Document:

--- a/mmda/parsers/symbol_scraper_parser.py
+++ b/mmda/parsers/symbol_scraper_parser.py
@@ -20,14 +20,14 @@ from mmda.types.span import Span
 from mmda.types.box import Box
 from mmda.types.annotation import SpanGroup
 from mmda.types.document import Document
-from mmda.parsers.parser import BaseParser
+from mmda.parsers.parser import Parser
 from mmda.types.names import *
 
 
 logger = logging.getLogger(__name__)
 
 
-class SymbolScraperParser(BaseParser):
+class SymbolScraperParser(Parser):
     def __init__(self, sscraper_bin_path: str, dpi:int = None):
         self.dpi = dpi
         self.sscraper_bin_path = sscraper_bin_path

--- a/mmda/parsers/symbol_scraper_parser.py
+++ b/mmda/parsers/symbol_scraper_parser.py
@@ -32,9 +32,7 @@ class SymbolScraperParser(Parser):
         self.dpi = dpi
         self.sscraper_bin_path = sscraper_bin_path
 
-    def parse(self, input_pdf_path: str, output_json_path: Optional[str] = None,
-              tempdir: Optional[str] = None, load_images=False) -> Document:
-
+    def parse(self, input_pdf_path: str, tempdir: Optional[str] = None) -> Document:
         if tempdir is None:
             with tempfile.TemporaryDirectory() as tempdir:
                 xmlfile = self._run_sscraper(input_pdf_path=input_pdf_path, outdir=tempdir)
@@ -42,15 +40,6 @@ class SymbolScraperParser(Parser):
         else:
             xmlfile = self._run_sscraper(input_pdf_path=input_pdf_path, outdir=tempdir)
             doc: Document = self._parse_xml_to_doc(xmlfile=xmlfile)
-
-        if load_images:
-            doc.images = self.load_images(input_pdf_path)
-
-        # TODO: remove `indent=4` for storage efficiency
-        if output_json_path:
-            with open(output_json_path, 'w') as f_out:
-                json.dump(doc.to_json(), f_out, indent=4)
-
         return doc
 
     #

--- a/mmda/rasterizers/rasterizer.py
+++ b/mmda/rasterizers/rasterizer.py
@@ -3,11 +3,11 @@ from abc import abstractmethod
 from typing import List, Optional, Protocol, Union
 
 from mmda.types.document import Document
-from mmda.types.image import load_pdf_images_from_path
+from mmda.types.image import load_pdf_images_from_path, PILImage
 
 
 class Rasterizer(Protocol):
-    def rasterize(self, input_pdf_path: str, dpi: int, **kwargs) -> List["PIL.Image"]:
+    def rasterize(self, input_pdf_path: str, dpi: int, **kwargs) -> List[PILImage]:
         """Given an input PDF return a List[Image]
 
         Args:

--- a/mmda/rasterizers/rasterizer.py
+++ b/mmda/rasterizers/rasterizer.py
@@ -1,0 +1,24 @@
+
+from abc import abstractmethod
+from typing import List, Optional, Protocol, Union
+
+from mmda.types.document import Document
+from mmda.types.image import load_pdf_images_from_path
+
+
+class Rasterizer(Protocol):
+    def rasterize(self, input_pdf_path: str, dpi: int, **kwargs) -> List["PIL.Image"]:
+        """Given an input PDF return a List[Image]
+
+        Args:
+            input_pdf_path (str): Path to the input PDF to process
+            dpi (int): Used for specify the resolution (or `DPI, dots per inch
+                       <https://en.wikipedia.org/wiki/Dots_per_inch>`_) when loading images of
+                       the pdf. Higher DPI values mean clearer images (also larger file sizes).
+
+        Returns:
+            List[Image]
+        """
+        images = load_pdf_images_from_path(pdf_path=input_pdf_path, dpi=dpi)
+        return images
+

--- a/mmda/rasterizers/rasterizer.py
+++ b/mmda/rasterizers/rasterizer.py
@@ -1,12 +1,14 @@
 
 from abc import abstractmethod
-from typing import List, Optional, Protocol, Union
+from typing import List, Optional, Union
+
+import pdf2image
 
 from mmda.types.document import Document
-from mmda.types.image import load_pdf_images_from_path, PILImage
+from mmda.types.image import PILImage
 
 
-class Rasterizer(Protocol):
+class Rasterizer:
     def rasterize(self, input_pdf_path: str, dpi: int, **kwargs) -> List[PILImage]:
         """Given an input PDF return a List[Image]
 
@@ -19,6 +21,6 @@ class Rasterizer(Protocol):
         Returns:
             List[Image]
         """
-        images = load_pdf_images_from_path(pdf_path=input_pdf_path, dpi=dpi)
+        images = pdf2image.convert_from_path(pdf_path=input_pdf_path, dpi=dpi)
         return images
 

--- a/mmda/types/document.py
+++ b/mmda/types/document.py
@@ -16,11 +16,10 @@ import warnings
 
 from mmda.types.box import Box
 from mmda.types.span import Span
-from mmda.types.image import Image
+from mmda.types.image import pilimage, PILImage
 from mmda.types.annotation import Annotation, BoxGroup, SpanGroup
 from mmda.types.indexers import Indexer, SpanGroupIndexer
 from mmda.types.names import Symbols, Images
-from mmda.types.image import Image as DocImage
 from mmda.utils.tools import merge_neighbor_spans, find_overlapping_tokens_for_box, allocate_overlapping_tokens_for_box
 
 class Document:
@@ -28,7 +27,7 @@ class Document:
     REQUIRED_FIELDS = [Symbols, Images]
     UNALLOWED_FIELD_NAMES = ['fields']
 
-    def __init__(self, symbols: str, images: Optional[List["Image.Image"]] = None):
+    def __init__(self, symbols: str, images: Optional[List[PILImage]] = None):
         self.symbols = symbols
         self.images = images if images else []
         self.__fields = []
@@ -199,7 +198,7 @@ class Document:
         symbols = doc_dict[Symbols]
         images_dict = doc_dict.get(Images, None)
         if images_dict:
-            images = [DocImage.frombase64(image_str) for image_str in images_dict]
+            images = [PILImage.frombase64(image_str) for image_str in images_dict]
         else:
             images = None
         doc = cls(symbols=symbols, images=images)
@@ -262,7 +261,7 @@ class Document:
             image_files = sorted(
                 image_files, key=lambda x: int(os.path.basename(x).replace('.png', ''))
             )
-            images = [Image.load(image_file) for image_file in image_files]     # TODO[kylel]: not how to load PIL images
+            images = [PILImage.load(image_file) for image_file in image_files]
         else:
             json_path = path
             images = None

--- a/mmda/types/image.py
+++ b/mmda/types/image.py
@@ -27,6 +27,7 @@ def frombase64(img_str):
     img = pilimage.open(buffered)
     return img
 
+
 load_pdf_images_from_path = _convert_from_path 
 PILImage.tobase64 = tobase64 # This is the method applied to individual Image classes
 PILImage.to_json = tobase64 # Use the same API as the others

--- a/mmda/types/image.py
+++ b/mmda/types/image.py
@@ -7,7 +7,6 @@ Monkey patch the PIL.Image methods to add base64 conversion
 
 import base64
 from io import BytesIO
-from pdf2image import convert_from_path as _convert_from_path
 
 from PIL import Image as pilimage
 from PIL.Image import Image as PILImage
@@ -28,7 +27,6 @@ def frombase64(img_str):
     return img
 
 
-load_pdf_images_from_path = _convert_from_path 
 PILImage.tobase64 = tobase64 # This is the method applied to individual Image classes
 PILImage.to_json = tobase64 # Use the same API as the others
 PILImage.frombase64 = frombase64 # This is bind to the module, used for loading the images

--- a/mmda/types/image.py
+++ b/mmda/types/image.py
@@ -9,7 +9,8 @@ import base64
 from io import BytesIO
 from pdf2image import convert_from_path as _convert_from_path
 
-from PIL import Image
+from PIL import Image as pilimage
+from PIL.Image import Image as PILImage
 
 
 def tobase64(self):
@@ -23,10 +24,10 @@ def tobase64(self):
 def frombase64(img_str):
     # Use the same naming style as the original Image methods
     buffered = BytesIO(base64.b64decode(img_str))
-    img = Image.open(buffered)
+    img = pilimage.open(buffered)
     return img
 
 load_pdf_images_from_path = _convert_from_path 
-Image.Image.tobase64 = tobase64 # This is the method applied to individual Image classes
-Image.Image.to_json = tobase64 # Use the same API as the others
-Image.frombase64 = frombase64 # This is bind to the module, used for loading the images
+PILImage.tobase64 = tobase64 # This is the method applied to individual Image classes
+PILImage.to_json = tobase64 # Use the same API as the others
+PILImage.frombase64 = frombase64 # This is bind to the module, used for loading the images


### PR DESCRIPTION
1. Rasterizer handles PDF->Image.  It's separate from Parser.
2. Remove dpi=72 default value.
3. Clean up PIL.Image import names to be less confusing
4. Update library tests
5. Update SScraper predictor service to use Rasterizer