### PR TITLE
Skip pages with no tokens

### DIFF
--- a/mmda/predictors/hf_predictors/vila_predictor.py
+++ b/mmda/predictors/hf_predictors/vila_predictor.py
@@ -147,20 +147,21 @@ class BaseVILAPredictor(BaseHFPredictor):
         page_prediction_results = []
         for page_id, page in enumerate(tqdm(document.pages)):
 
-            page_width, page_height = document.images[page_id].size
+            if page.tokens:
+                page_width, page_height = document.images[page_id].size
 
-            pdf_dict = convert_document_page_to_pdf_dict(
-                page, page_width=page_width,page_height=page_height
-            )
-            # VILA models trained based on absolute page width rather than the
-            # size (1000, 1000) in vanilla LayoutLM models 
-            
-            model_inputs = self.preprocess(pdf_dict)
-            model_outputs = self.model(**self.model_input_collator(model_inputs))
-            model_predictions = self.get_category_prediction(model_outputs)
-            page_prediction_results.extend(
-                self.postprocess(page, pdf_dict, model_inputs, model_predictions)
-            )
+                pdf_dict = convert_document_page_to_pdf_dict(
+                    page, page_width=page_width,page_height=page_height
+                )
+                # VILA models trained based on absolute page width rather than the
+                # size (1000, 1000) in vanilla LayoutLM models
+
+                model_inputs = self.preprocess(pdf_dict)
+                model_outputs = self.model(**self.model_input_collator(model_inputs))
+                model_predictions = self.get_category_prediction(model_outputs)
+                page_prediction_results.extend(
+                    self.postprocess(page, pdf_dict, model_inputs, model_predictions)
+                )
 
         return page_prediction_results
 

--- a/mmda/types/document.py
+++ b/mmda/types/document.py
@@ -21,7 +21,7 @@ from mmda.utils.tools import allocate_overlapping_tokens_for_box, merge_neighbor
 
 class Document:
 
-    REQUIRED_FIELDS = [Symbols]
+    SPECIAL_FIELDS = [Symbols, Images]
     UNALLOWED_FIELD_NAMES = ["fields"]
 
     def __init__(self, symbols: str):
@@ -51,8 +51,8 @@ class Document:
         # 1) check validity of field names
         for field_name in kwargs.keys():
             assert (
-                field_name not in self.REQUIRED_FIELDS
-            ), f"The field_name {field_name} should not be in {self.REQUIRED_FIELDS}."
+                field_name not in self.SPECIAL_FIELDS
+            ), f"The field_name {field_name} should not be in {self.SPECIAL_FIELDS}."
 
             assert field_name not in dir(
                 self
@@ -263,7 +263,7 @@ class Document:
         # 2) convert span group dicts to span gropus
         field_name_to_span_groups = {}
         for field_name, span_group_dicts in doc_dict.items():
-            if field_name not in doc.REQUIRED_FIELDS:
+            if field_name not in doc.SPECIAL_FIELDS:
                 span_groups = [
                     SpanGroup.from_json(span_group_dict=span_group_dict)
                     for span_group_dict in span_group_dicts


### PR DESCRIPTION
To avoid timeouts when calling VILA, ScienceParsePlus needs to split large documents into fixed-page-length. It does this by filtering the tokens and blocks to a given page range. Change the VILA predictor to tolerate pages that have no tokens. This is probably possible in general anyway, for example if a PDF has a full-page image.

SPP breaks up the document by keeping the full symbols string, image list, and page annotations. It would be more space efficient to replace the symbols with the sub-range that applies to the pages being sent, and adjusting all of the span offsets. That's still possible, but I'll leave that to a future optimization.

Also, https://github.com/allenai/mmda/pull/62 broke the `document.from_json()` method. I guess there are no tests that would catch that? This PR fixes the error, but maybe there's another way to fix it in light of the discussion in https://github.com/allenai/mmda/pull/62.

@rauthur @lolipopshock 