### PR TITLE
Allow nested annotations on a span group

### DIFF
--- a/examples/bibliography_extraction/main.py
+++ b/examples/bibliography_extraction/main.py
@@ -121,6 +121,10 @@ page_num = _find_page_num(bib, _index_document_pages(document))
 page_blocks = [b for b in blocks if b.boxes[0].page == page_num]
 block_tokens = defaultdict(list)
 
+import pdb
+
+pdb.set_trace()
+
 # Group bib tokes into a block
 for token in bib.tokens:
     highest_overlap_block = _highest_overlap_block(token, page_blocks)

--- a/mmda/types/document.py
+++ b/mmda/types/document.py
@@ -5,15 +5,12 @@
 """
 
 import itertools
-import json
-import os
 import warnings
 from copy import deepcopy
-from glob import glob
 from typing import Dict, Iterable, List, Optional
 
 from mmda.types.annotation import Annotation, BoxGroup, SpanGroup
-from mmda.types.image import PILImage, pilimage
+from mmda.types.image import PILImage
 from mmda.types.indexers import Indexer, SpanGroupIndexer
 from mmda.types.names import Images, Symbols
 from mmda.utils.tools import allocate_overlapping_tokens_for_box, merge_neighbor_spans

--- a/mmda/types/document.py
+++ b/mmda/types/document.py
@@ -125,7 +125,6 @@ class Document:
 
         new_span_group_indexer = SpanGroupIndexer()
         for span_group in span_groups:
-
             # 1) add Document to each SpanGroup
             span_group.attach_doc(doc=self)
 
@@ -166,7 +165,6 @@ class Document:
             for box in box_group.boxes:
 
                 # Caching the page tokens to avoid duplicated search
-
                 if box.page not in all_page_tokens:
                     cur_page_tokens = all_page_tokens[box.page] = list(
                         itertools.chain.from_iterable(
@@ -271,4 +269,3 @@ class Document:
         doc.annotate(**field_name_to_span_groups)
 
         return doc
-

--- a/mmda/types/user_data.py
+++ b/mmda/types/user_data.py
@@ -1,0 +1,49 @@
+"""
+
+UserData and HasUserData allow a Python class to have an underscore `_` property for
+accessing custom fields. Data captured within this property can be serialized along with
+any instance of the class.
+
+"""
+from typing import Any, Callable, Dict, Optional
+
+
+class UserData:
+    _data: Dict[str, Any]
+    _callback: Optional[Callable[[Any], None]]
+
+    def __init__(self, after_set_callback: Callable[[Any], None] = None):
+        # Use object.__setattr__ to avoid loop on self.__setattr__ during init
+        object.__setattr__(self, "_data", dict())
+        object.__setattr__(self, "_callback", after_set_callback)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if object.__getattribute__(self, name):
+            raise ValueError(f"Cannot set reserved name {name}!")
+
+        self._data.__setitem__(name, value)
+
+        if not self._callback:
+            return
+
+        self._callback(name, value)
+
+    def __delattr__(self, name: str) -> None:
+        self._data.__delitem__(name)
+
+    def __getattr__(self, name: str) -> Any:
+        return self._data[name]
+
+    def keys(self):
+        return self._data.keys()
+
+
+class HasUserData:
+    _user_data: UserData
+
+    def __init__(self, after_set_callback=None):
+        self._user_data = UserData(after_set_callback=after_set_callback)
+
+    @property
+    def _(self):
+        return self._user_data

--- a/tests/test_predictors/test_dictionary_word_predictor.py
+++ b/tests/test_predictors/test_dictionary_word_predictor.py
@@ -6,9 +6,7 @@ Tests for DictionaryWordPredictor
 
 import tempfile
 import unittest
-
-from typing import Optional, Set, List
-
+from typing import List, Optional, Set
 
 from mmda.predictors.heuristic_predictors.dictionary_word_predictor import (
     DictionaryWordPredictor,
@@ -20,7 +18,9 @@ from mmda.types.span import Span
 def mock_document(symbols: str, spans: List[Span], rows: List[SpanGroup]) -> Document:
     doc = Document(symbols=symbols)
     doc.annotate(rows=rows)
-    doc.annotate(tokens=[SpanGroup(spans=[span]) for span in spans])
+    doc.annotate(
+        tokens=[SpanGroup(id=i + 1, spans=[span]) for i, span in enumerate(spans)]
+    )
     return doc
 
 
@@ -51,7 +51,7 @@ class TestDictionaryWordPredictor(unittest.TestCase):
             Span(start=72, end=77),  # tasks
         ]
 
-        rows = [SpanGroup(spans=spans[0:12]), SpanGroup(spans=spans[12:])]
+        rows = [SpanGroup(id=1, spans=spans[0:12]), SpanGroup(id=2, spans=spans[12:])]
         document = mock_document(symbols=text, spans=spans, rows=rows)
 
         with tempfile.NamedTemporaryFile() as f:
@@ -93,7 +93,7 @@ class TestDictionaryWordPredictor(unittest.TestCase):
             Span(start=72, end=77),  # tasks
         ]
 
-        rows = [SpanGroup(spans=spans[0:12]), SpanGroup(spans=spans[12:])]
+        rows = [SpanGroup(id=1, spans=spans[0:12]), SpanGroup(id=2, spans=spans[12:])]
         document = mock_document(symbols=text, spans=spans, rows=rows)
 
         with tempfile.NamedTemporaryFile() as f:
@@ -131,7 +131,7 @@ class TestDictionaryWordPredictor(unittest.TestCase):
             Span(start=59, end=65),  # manner
         ]
 
-        rows = [SpanGroup(spans=spans[0:11]), SpanGroup(spans=spans[11:])]
+        rows = [SpanGroup(id=1, spans=spans[0:11]), SpanGroup(id=2, spans=spans[11:])]
         document = mock_document(symbols=text, spans=spans, rows=rows)
 
         with tempfile.NamedTemporaryFile() as f:
@@ -169,9 +169,9 @@ class TestDictionaryWordPredictor(unittest.TestCase):
         ]
 
         rows = [
-            SpanGroup(spans=spans[0:5]),
-            SpanGroup(spans=spans[5:10]),
-            SpanGroup(spans=spans[10:]),
+            SpanGroup(id=1, spans=spans[0:5]),
+            SpanGroup(id=2, spans=spans[5:10]),
+            SpanGroup(id=3, spans=spans[10:]),
         ]
         document = mock_document(symbols=text, spans=spans, rows=rows)
 
@@ -201,8 +201,8 @@ class TestDictionaryWordPredictor(unittest.TestCase):
         ]
 
         rows = [
-            SpanGroup(spans=spans[0:2]),
-            SpanGroup(spans=spans[2:3]),
+            SpanGroup(id=1, spans=spans[0:2]),
+            SpanGroup(id=2, spans=spans[2:3]),
         ]
         document = mock_document(symbols=text, spans=spans, rows=rows)
 

--- a/tests/test_types/test_span_group.py
+++ b/tests/test_types/test_span_group.py
@@ -56,3 +56,61 @@ class TestSpanGroup(unittest.TestCase):
         nested_span_group = span_group.capitalized[0]
         self.assertEqual("This", nested_span_group.text)
         self.assertEqual(["This"], nested_span_group.symbols)
+
+    def test_deep_nesting_without_id_conflicts(self):
+        span_group = SpanGroup(id=1, spans=[Span(0, 4), Span(5, 7)])
+        nested_span_group = SpanGroup(
+            id=2, spans=[Span(0, 4), Span(5, 7)], text="This is"
+        )
+        deep_span_group = SpanGroup(id=3, spans=[Span(0, 4)], text="This")
+
+        self.doc.annotate(tokens=[span_group])
+
+        span_group = self.doc.tokens[0]
+        span_group.annotate(capitalized=[nested_span_group])
+
+        nested_span_group = span_group.capitalized[0]
+        nested_span_group.annotate(deep=[deep_span_group])
+
+        json_repr = self.doc.to_json()
+        new_doc = Document.from_json(json_repr)
+
+        span_group = new_doc.tokens[0]
+        self.assertEqual(["This", "is"], span_group.symbols)
+
+        nested_span_group = span_group.capitalized[0]
+        self.assertEqual("This is", nested_span_group.text)
+        self.assertEqual(["This", "is"], nested_span_group.symbols)
+
+        deep_span_group = nested_span_group.deep[0]
+        self.assertEqual("This", deep_span_group.text)
+        self.assertEqual(["This"], deep_span_group.symbols)
+
+    def test_deep_nesting_with_id_conflicts(self):
+        span_group = SpanGroup(id=1, spans=[Span(0, 4), Span(5, 7)])
+        nested_span_group = SpanGroup(
+            id=1, spans=[Span(0, 4), Span(5, 7)], text="This is"
+        )
+        deep_span_group = SpanGroup(id=1, spans=[Span(0, 4)], text="This")
+
+        self.doc.annotate(tokens=[span_group])
+
+        span_group = self.doc.tokens[0]
+        span_group.annotate(capitalized=[nested_span_group])
+
+        nested_span_group = span_group.capitalized[0]
+        nested_span_group.annotate(deep=[deep_span_group])
+
+        json_repr = self.doc.to_json()
+        new_doc = Document.from_json(json_repr)
+
+        span_group = new_doc.tokens[0]
+        self.assertEqual(["This", "is"], span_group.symbols)
+
+        nested_span_group = span_group.capitalized[0]
+        self.assertEqual("This is", nested_span_group.text)
+        self.assertEqual(["This", "is"], nested_span_group.symbols)
+
+        deep_span_group = nested_span_group.deep[0]
+        self.assertEqual("This", deep_span_group.text)
+        self.assertEqual(["This"], deep_span_group.symbols)

--- a/tests/test_types/test_span_group.py
+++ b/tests/test_types/test_span_group.py
@@ -1,0 +1,58 @@
+"""
+Tests for SpanGroup
+
+@rauthur
+"""
+
+import json
+import unittest
+
+from mmda.types.annotation import SpanGroup
+from mmda.types.document import Document
+from mmda.types.span import Span
+
+
+class TestSpanGroup(unittest.TestCase):
+    doc: Document
+
+    def setUp(self) -> None:
+        self.doc = Document("This is a test document!")
+
+    def test_annotation_attaches_document(self):
+        span_group = SpanGroup(id=1, spans=[Span(0, 4), Span(5, 7)])
+        self.doc.annotate(tokens=[span_group])
+
+        span_group = self.doc.tokens[0]
+        self.assertEqual(["This", "is"], span_group.symbols)
+
+    def test_annotation_allows_nesting(self):
+        span_group = SpanGroup(id=1, spans=[Span(0, 4), Span(5, 7)])
+        nested_span_group = SpanGroup(id=2, spans=[Span(0, 4)], text="This")
+
+        self.doc.annotate(tokens=[span_group])
+
+        span_group = self.doc.tokens[0]
+        span_group.annotate(capitalized=[nested_span_group])
+
+        nested_span_group = span_group.capitalized[0]
+        self.assertEqual("This", nested_span_group.text)
+        self.assertEqual(["This"], nested_span_group.symbols)
+
+    def test_serialization_with_nesting(self):
+        span_group = SpanGroup(id=1, spans=[Span(0, 4), Span(5, 7)])
+        nested_span_group = SpanGroup(id=2, spans=[Span(0, 4)], text="This")
+
+        self.doc.annotate(tokens=[span_group])
+
+        span_group = self.doc.tokens[0]
+        span_group.annotate(capitalized=[nested_span_group])
+
+        json_repr = self.doc.to_json()
+        new_doc = Document.from_json(json_repr)
+
+        span_group = new_doc.tokens[0]
+        self.assertEqual(["This", "is"], span_group.symbols)
+
+        nested_span_group = span_group.capitalized[0]
+        self.assertEqual("This", nested_span_group.text)
+        self.assertEqual(["This"], nested_span_group.symbols)


### PR DESCRIPTION
An idea... Not my favorite but the branch [types-nouveau](https://github.com/allenai/mmda/tree/types-nouveau) refactoring would take very long to roll out to all the created predictors, etc. Please reference that branch for the original idea (a layer of typing).

Annotations are always stored on the top-level document with a special key when nested.

1. [x] Tests need fixing ... 
2. [x] Examples need fixing ...
3. [x] Deeply nested annotations can have ID conflict easily

Example JSON format:

```json
{
   "symbols":"This is a test document!",
   "tokens":[
      {
         "spans":[
            {
               "start":0,
               "end":4
            },
            {
               "start":5,
               "end":7
            }
         ],
         "id":1,
         "uuid":"997031e4-bbb5-4216-ace7-a88e410df7af"
      }
   ],
   "SpanGroup|997031e4-bbb5-4216-ace7-a88e410df7af|capitalized":[
      {
         "spans":[
            {
               "start":0,
               "end":4
            },
            {
               "start":5,
               "end":7
            }
         ],
         "id":1,
         "text":"This is",
         "uuid":"024de04b-7af3-4c51-bf22-74d5f6d231b4"
      }
   ],
   "SpanGroup|024de04b-7af3-4c51-bf22-74d5f6d231b4|deep":[
      {
         "spans":[
            {
               "start":0,
               "end":4
            }
         ],
         "id":1,
         "text":"This",
         "uuid":"5b613676-18be-4893-b7d2-549c0a6faec6"
      }
   ]
}
```