### PR TITLE
PdfPlumber: fix for if page has no tokens

### DIFF
--- a/mmda/parsers/pdfplumber_parser.py
+++ b/mmda/parsers/pdfplumber_parser.py
@@ -265,17 +265,20 @@ class PDFPlumberParser(Parser):
                 page_rows.append(row)
                 row_annos.append(row)
             # make page
-            page = SpanGroup(
-                spans=[
-                    Span(
-                        start=page_rows[0][0].start,
-                        end=page_rows[-1][0].end,
-                        box=Box.small_boxes_to_big_box(
-                            boxes=[span.box for r in page_rows for span in r]
-                        ),
-                    )
-                ]
-            )
+            if page_rows:
+                page = SpanGroup(
+                    spans=[
+                        Span(
+                            start=page_rows[0][0].start,
+                            end=page_rows[-1][0].end,
+                            box=Box.small_boxes_to_big_box(
+                                boxes=[span.box for r in page_rows for span in r]
+                            ),
+                        )
+                    ]
+                )
+            else:
+                page = SpanGroup(spans=[])
             page_annos.append(page)
         # add IDs
         for i, page in enumerate(page_annos):


### PR DESCRIPTION
we are getting some PdfPlumber errors like [this](https://app.datadoghq.com/logs?query=source%3Aspp%20env%3Aprod%20status%3A%28error%20OR%20critical%20OR%20info%29&cols=service&event=AQAAAX9L3ZOrltRcPQAAAABBWDlMM2FCWkFBQTFTNTByM1NKT1lBQUI&index=main&integration_id=&integration_short_name=&messageDisplay=inline&saved_view=750965&stream_sort=desc&viz=stream&from_ts=1646245258312&to_ts=1646245320495&live=false) in the scienceparseplus project:
```
  File "/usr/local/lib/python3.8/site-packages/mmda/parsers/pdfplumber_parser.py", line 158, in parse
    doc = self._load_pdf_as_doc(input_pdf_path)
  File "/usr/local/lib/python3.8/site-packages/mmda/parsers/pdfplumber_parser.py", line 297, in _load_pdf_as_doc
    doc_json = self._convert_nested_text_to_doc_json(page_to_line_to_tokens)
  File "/usr/local/lib/python3.8/site-packages/mmda/parsers/pdfplumber_parser.py", line 271, in _convert_nested_text_to_doc_json
    start=page_rows[0][0].start,
IndexError: list index out of range
```

I think this will fix it and not disrupt anything else
todo: 
- [x] test pdfplumber in spp using this branch 