### PR TITLE
Additional checks for pdfplumber parser

### DIFF
--- a/mmda/parsers/pdfplumber_parser.py
+++ b/mmda/parsers/pdfplumber_parser.py
@@ -183,14 +183,16 @@ class PDFPlumberParser(Parser):
         page_tokens = [
             {
                 "text": token["text"],
-                "bbox": Box.from_coordinates(
+                "bbox": Box.from_pdf_coordinates(
                     x1=float(token["x0"]),
                     y1=float(token["top"]),
                     x2=float(token["x1"]),
                     y2=float(token["bottom"]),
+                    page_width=page.width, 
+                    page_height=page.height,
                     page=page_index,
                 ).get_relative(
-                    page_width=float(page.width), page_height=float(page.height)
+                    page_width=page.width, page_height=page.height
                 ),
             }
             for token in token_data

--- a/mmda/types/box.py
+++ b/mmda/types/box.py
@@ -63,9 +63,9 @@ class Box:
         _x1, _x2 = np.clip([x1, x2], 0, page_width)
         _y1, _y2 = np.clip([y1, y2], 0, page_height)
 
-        if _x2 > _x1:
+        if _x2 < _x1:
             _x2 = _x1
-        if _y2 > _y1:
+        if _y2 < _y1:
             _y2 = _y1
         if (_x1, _y1, _x2, _y2) != (x1, y1, x2, y2):
             warnings.warn(

--- a/tests/test_parsers/test_grobid_header_parser.py
+++ b/tests/test_parsers/test_grobid_header_parser.py
@@ -1,8 +1,12 @@
+import os
+import pathlib
 import unittest
 import unittest.mock as um
 
 import pytest
 from mmda.parsers.grobid_parser import GrobidHeaderParser
+
+os.chdir(pathlib.Path(__file__).parent)
 
 XML_OK = open("../fixtures/grobid-tei-maml-header.xml").read()
 XML_NO_TITLE = open("../fixtures/grobid-tei-no-title.xml").read()


### PR DESCRIPTION
Sometimes PDF Parsers will return token coordinates with negative or extra large values (larger than the page_width/height). This is not a bug but a feature designed in the "printing commands" of PDF grammars. However, this will break our models and many downstream processing. 

This issue aims to fix this issue via adding additional checks for PDFPlumber Parsers. It brings similar clipping functions in the VILA repo https://github.com/allenai/VILA/blob/6a5c6783b75eefaeaed01b67bc3be025add9cde3/src/vila/pdftools/pdfplumber_extractor.py#L204 to the mmda PDFPlumberParsers to increase the robustness of token parsers. 

Some examples: 

Previously a token will have a box like (the box is outside the page range)
```python
box=Box(l=0.10764222310323279, t=-0.35593721269999645, w=0.02696391589783563, h=0.009478672985782012, page=7)
```
While after this fix, it will be
```python
Box(l=0.10751146308724832, t=0.0, w=0.026931161073825507, h=0.0, page=None)
```