### PR TITLE
VILA models crashing when bounding boxes are not int

### DIFF
--- a/mmda/predictors/heuristic_predictors/sentence_boundary_predictor.py
+++ b/mmda/predictors/heuristic_predictors/sentence_boundary_predictor.py
@@ -143,6 +143,6 @@ class PysbdSentenceBoundaryPredictor(BaseHeuristicPredictor):
                 itertools.chain.from_iterable([ele.spans for ele in cur_spans])
             )
 
-            sentence_spans.append(SpanGroup(merge_neighbor_spans(all_token_spans)))
+            sentence_spans.append(SpanGroup(spans=merge_neighbor_spans(all_token_spans)))
 
         return sentence_spans

--- a/mmda/predictors/hf_predictors/utils.py
+++ b/mmda/predictors/hf_predictors/utils.py
@@ -62,6 +62,9 @@ def convert_document_page_to_pdf_dict(
         ).coordinates
         for token in document.tokens
     ]
+    # bounding boxes can be float, but VILA wants ints, so
+    # we round to int after getting the absolute coordinates.
+    bbox = [tuple(map(round, coord)) for coord in bbox]
 
     line_ids = [get_visual_group_id(token, Rows, -1) for token in document.tokens]
     # TODO: Right now we assume the token could span for one row of the document.


### PR DESCRIPTION

VILA models crashing when bounding boxes are not int




Because of changes in #69 , bounding boxes are now float instead of int, which VILA does not like:

```bash
  File "/Users/lucas/miniforge3/envs/pdod/lib/python3.10/site-packages/mmda/predictors/hf_predictors/vila_predictor.py", line 161, in predict
    model_outputs = self.model(**self.model_input_collator(model_inputs))
  File "/Users/lucas/miniforge3/envs/pdod/lib/python3.10/site-packages/mmda/predictors/hf_predictors/vila_predictor.py", line 178, in model_input_collator
    return {
  File "/Users/lucas/miniforge3/envs/pdod/lib/python3.10/site-packages/mmda/predictors/hf_predictors/vila_predictor.py", line 179, in <dictcomp>
    key: torch.tensor(val, dtype=torch.int64, device=self.device)
TypeError: 'float' object cannot be interpreted as an integer
```

This PR adds an explicit cast operation to get around this issue during pre-processing. 