### PR TITLE
Pins vila to 0.3.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="mmda",
-    version="0.0.10",
+    version="0.0.11",
     python_requires=">= 3.7",
     packages=setuptools.find_packages(include=["mmda*", "ai2_internal*"]),
     install_requires=[
@@ -19,7 +19,7 @@ setuptools.setup(
         "api": ["Flask", "gevent"],
         "pipeline": ["requests"],
         "lp_predictors": ["layoutparser", "torch", "torchvision", "effdet"],
-        "vila_predictors": ["vila >= 0.3.0", "transformers"],
+        "vila_predictors": ["vila==0.3.0", "transformers"],
         "bibentry_predictor": ["transformers", "unidecode", "torch"],
     },
     include_package_data=True,


### PR DESCRIPTION
Unbounded upper version was pulling in breaking
changes transitively in builds.