### PR TITLE
use set membership instead of list membership

### DIFF
--- a/mmda/types/indexers.py
+++ b/mmda/types/indexers.py
@@ -34,13 +34,14 @@ class SpanGroupIndexer(Indexer):
         if not isinstance(query, SpanGroup):
             raise ValueError(f'SpanGroupIndexer only works with `query` that is SpanGroup type')
 
-        all_matched_span_groups = []
+        all_matched_span_groups = dict()
+
         for span in query.spans:
             for matched_span_group in self._index[span.start : span.end]:
-                if matched_span_group.data not in all_matched_span_groups: # Deduplicate
-                    all_matched_span_groups.append(matched_span_group.data)
-        # retrieval can be out of order, so sort
-        return sorted(all_matched_span_groups)
+                object_id = id(matched_span_group.data)
+                all_matched_span_groups[object_id] = matched_span_group.data
+
+        return sorted(list(all_matched_span_groups.values()))
 
     def __getitem__(self, key):
         return self._index[key]

--- a/mmda/types/indexers.py
+++ b/mmda/types/indexers.py
@@ -41,6 +41,7 @@ class SpanGroupIndexer(Indexer):
                 object_id = id(matched_span_group.data)
                 all_matched_span_groups[object_id] = matched_span_group.data
 
+        # Sort these because matching logic above doesn't preserve order
         return sorted(list(all_matched_span_groups.values()))
 
     def __getitem__(self, key):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="mmda",
-    version="0.0.15",
+    version="0.0.16",
     python_requires=">= 3.7",
     packages=setuptools.find_packages(include=["mmda*", "ai2_internal*"]),
     install_requires=[


### PR DESCRIPTION
Deduplication logic was causing big slow-down in
real world deployments of MMDA models.

The current changeset uses object id to do set
membership checks instead of list membership checks.

Using production S2 data, this resulted in an approximately 400-fold
reduction in `indexers.py` latency for VILA, with identical
output to prior implementation.

Kudos to @Whattabatt both for the profiler tool
that identified the offending line and noticing the `not in`
was likely a linear operation.

<img width="1277" alt="Screen Shot 2022-07-20 at 5 08 26 PM" src="https://user-images.githubusercontent.com/1287054/180103170-8fd33afd-dd7b-483a-9257-a0468a469b8f.png">

<img width="1283" alt="Screen Shot 2022-07-20 at 5 08 11 PM" src="https://user-images.githubusercontent.com/1287054/180103194-fe0a7228-3b40-4b83-93a9-af63dce64078.png">
