### PR TITLE
Replaces interval tree for ncls

### DIFF
--- a/mmda/types/document.py
+++ b/mmda/types/document.py
@@ -123,27 +123,12 @@ class Document:
         """
         assert all([isinstance(group, SpanGroup) for group in span_groups])
 
-        new_span_group_indexer = SpanGroupIndexer()
+        # 1) add Document to each SpanGroup
         for span_group in span_groups:
-            # 1) add Document to each SpanGroup
             span_group.attach_doc(doc=self)
 
-            # 2) for each span in span_group, (a) check if any conflicts (requires disjointedness).
-            #    then (b) add span group to index at this span location
-            #  TODO: can be cleaned up; encapsulate the checker somewhere else
-            for span in span_group:
-                # a) Check index if any conflicts (we require disjointness)
-                matched_span_group = new_span_group_indexer[span.start : span.end]
-                if matched_span_group:
-                    raise ValueError(
-                        f"Detected overlap with existing SpanGroup {matched_span_group} when attempting index {span_group}"
-                    )
-
-                # b) If no issues, add to index (for each span in span_group)
-                new_span_group_indexer[span.start : span.end] = span_group
-
-        # add new index to Doc
-        self.__indexers[field_name] = new_span_group_indexer
+        # 2) Build fast overlap lookup index
+        self.__indexers[field_name] = SpanGroupIndexer(span_groups)
 
         return span_groups
 

--- a/mmda/types/indexers.py
+++ b/mmda/types/indexers.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 
 from mmda.types.annotation import SpanGroup, Annotation
 from ncls import NCLS
+import numpy as np
 import pandas as pd
 
 
@@ -53,9 +54,9 @@ class SpanGroupIndexer(Indexer):
 
         self._sgs = span_groups
         self._index = NCLS(
-            pd.Series(starts),
-            pd.Series(ends),
-            pd.Series(ids)
+            pd.Series(starts, dtype=np.int64),
+            pd.Series(ends, dtype=np.int64),
+            pd.Series(ids, dtype=np.int64)
         )
 
         self._ensure_disjoint()

--- a/mmda/types/indexers.py
+++ b/mmda/types/indexers.py
@@ -90,6 +90,8 @@ class SpanGroupIndexer(Indexer):
         matched_span_groups = [self._sgs[matched_id] for matched_id in matched_ids]
 
         # Retrieval above doesn't preserve document order; sort here
+        # TODO: provide option to return matched span groups in same order as self._sgs
+        #   (the span groups the index was built with originally)
         return sorted(list(matched_span_groups))
 
 

--- a/mmda/types/indexers.py
+++ b/mmda/types/indexers.py
@@ -9,8 +9,9 @@ from typing import List
 from abc import abstractmethod
 from dataclasses import dataclass, field
 
-from intervaltree import IntervalTree
 from mmda.types.annotation import SpanGroup, Annotation
+from ncls import NCLS
+import pandas as pd
 
 
 @dataclass
@@ -21,31 +22,73 @@ class Indexer:
     @abstractmethod
     def find(self, query: Annotation) -> List[Annotation]:
         """Returns all matching Annotations given a suitable query"""
+        raise NotImplementedError()
 
 
-@dataclass
 class SpanGroupIndexer(Indexer):
+    """
+    Manages a data structure for locating overlapping SpanGroups.
+    Builds a static nested containment list from SpanGroups
+    and accepts other SpanGroups as search probes.
 
-    # careful; if write it as _index = IntervalTree(), all SpanGroupIndexers will share the same _index object
-    _index: IntervalTree = field(default_factory=IntervalTree)
+    See: https://github.com/biocore-ntnu/ncls
 
-    # TODO[kylel] - maybe have more nullable args for different types of queryes (just start/end ints, just SpanGroup)
+    [citation]
+    Alexander V. Alekseyenko, Christopher J. Lee;
+    Nested Containment List (NCList): a new algorithm for accelerating interval query of genome
+      alignment and interval databases, Bioinformatics,
+    Volume 23, Issue 11, 1 June 2007, Pages 1386–1393, https://doi.org/10.1093/bioinformatics/btl647
+    """
+
+    def __init__(self, span_groups: List[SpanGroup]) -> None:
+        starts = []
+        ends = []
+        ids = []
+
+        for sg_id, span_group in enumerate(span_groups):
+            for span in span_group.spans:
+                starts.append(span.start)
+                ends.append(span.end)
+                ids.append(sg_id)
+
+        self._sgs = span_groups
+        self._index = NCLS(
+            pd.Series(starts),
+            pd.Series(ends),
+            pd.Series(ids)
+        )
+
+        self._ensure_disjoint()
+
+    def _ensure_disjoint(self) -> None:
+        """
+        Constituent span groups must be fully disjoint.
+        Ensure the integrity of the built index.
+        """
+        for span_group in self._sgs:
+            for span in span_group.spans:
+                matches = [match for match in self._index.find_overlap(span.start, span.end)]
+                if len(matches) > 1:
+                    raise ValueError(
+                        f"Detected overlap with existing SpanGroup(s) {matches} for {span_group}"
+                    )
+
     def find(self, query: SpanGroup) -> List[SpanGroup]:
         if not isinstance(query, SpanGroup):
             raise ValueError(f'SpanGroupIndexer only works with `query` that is SpanGroup type')
 
-        all_matched_span_groups = dict()
+        if not query.spans:
+            return []
+
+        matched_ids = set()
 
         for span in query.spans:
-            for matched_span_group in self._index[span.start : span.end]:
-                object_id = id(matched_span_group.data)
-                all_matched_span_groups[object_id] = matched_span_group.data
+            for _start, _end, matched_id in self._index.find_overlap(span.start, span.end):
+                matched_ids.add(matched_id)
 
-        # Sort these because matching logic above doesn't preserve order
-        return sorted(list(all_matched_span_groups.values()))
+        matched_span_groups = [self._sgs[matched_id] for matched_id in matched_ids]
 
-    def __getitem__(self, key):
-        return self._index[key]
+        # Retrieval above doesn't preserve document order; sort here
+        return sorted(list(matched_span_groups))
 
-    def __setitem__(self, key, value):
-        self._index[key] = value
+

--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,19 @@ import setuptools
 
 setuptools.setup(
     name="mmda",
-    version="0.0.16",
+    description="mmda",
+    version="0.0.17-dev0",
+    url="https://www.github.com/allenai/mmda",
     python_requires=">= 3.7",
     packages=setuptools.find_packages(include=["mmda*", "ai2_internal*"]),
     install_requires=[
-        "intervaltree",
         "tqdm",
         "pdf2image",
         "pdfplumber",
         "requests",
         "pandas",
-        "pydantic"
+        "pydantic",
+        "ncls",
     ],
     extras_require={
         "dev": ["pytest"],


### PR DESCRIPTION
A substantial fraction of our real-world runtime was going
into querying the IntervalTree we use for detecting
SpanGroup overlaps.

This changeset replaces IntervalTree with NCLS:
https://github.com/biocore-ntnu/ncls,
a library that came out of genomics sequence
analysis research.

Profiling results indicate this improves inference times
on real-world S2 documents in VILA by a further
~42%.

Note:
@kyleclo  this library is made available under
`BSD 3-Clause "New" or "Revised" License`.
I don't know how that intersects with the Apache
license in this project.

The author also requests citation in any academic
publication.