### PR TITLE
Fix for `SpanGroup` creation in `PysbdSentenceBoundaryPredictor` that resulted in no sentences.

### DIFF
--- a/mmda/predictors/heuristic_predictors/sentence_boundary_predictor.py
+++ b/mmda/predictors/heuristic_predictors/sentence_boundary_predictor.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Dict, Any, Tuple
+from typing import List, Tuple
 import itertools
 
 import pysbd
@@ -7,20 +7,20 @@ import numpy as np
 from mmda.types.annotation import SpanGroup
 from mmda.types.span import Span
 from mmda.types.document import Document
-from mmda.types.names import *
+from mmda.types.names import Pages, Tokens, Words
 from mmda.predictors.base_predictors.base_heuristic_predictor import (
     BaseHeuristicPredictor,
 )
 
 
 def merge_neighbor_spans(spans: List[Span], distance=1) -> List[Span]:
-    """Merge neighboring spans in a list of un-overlapped spans: 
-    when the gaps between neighboring spans is not larger than the 
-    specified distance, they are considered as the neighbors.  
+    """Merge neighboring spans in a list of un-overlapped spans:
+    when the gaps between neighboring spans is not larger than the
+    specified distance, they are considered as the neighbors.
 
     Args:
-        spans (List[Span]): The input list of spans. 
-        distance (int, optional): 
+        spans (List[Span]): The input list of spans.
+        distance (int, optional):
             The upper bound of interval gaps between two neighboring spans.
             Defaults to 1.
 
@@ -34,11 +34,10 @@ def merge_neighbor_spans(spans: List[Span], distance=1) -> List[Span]:
         )
         <= distance
     )
-    # It assumes non-overlapped intervals within the list 
 
-    merge_neighboring_spans = lambda span1, span2: Span(
-        min(span1.start, span2.start), max(span1.end, span2.end)
-    )
+    # It assumes non-overlapped intervals within the list
+    def merge_neighboring_spans(span1, span2):
+        return Span(min(span1.start, span2.start), max(span1.end, span2.end))
 
     spans = sorted(spans, key=lambda ele: ele.start)
     # When sorted, only one iteration round is needed.
@@ -53,9 +52,11 @@ def merge_neighbor_spans(spans: List[Span], distance=1) -> List[Span]:
     for cur_span in spans[1:]:
         prev_span = cur_merged_spans.pop()
         if is_neighboring_spans(cur_span, prev_span):
-            cur_merged_spans.append(merge_neighboring_spans(prev_span, cur_span))
+            cur_merged_spans.append(
+                merge_neighboring_spans(prev_span, cur_span))
         else:
-            # In this case, the prev_span should be moved to the bottom of the stack
+            # In this case, the prev_span should be moved to the
+            # bottom of the stack
             cur_merged_spans.extend([prev_span, cur_span])
 
     return cur_merged_spans
@@ -72,18 +73,20 @@ class PysbdSentenceBoundaryPredictor(BaseHeuristicPredictor):
     """
 
     REQUIRED_BACKENDS = ["pysbd"]
-    REQUIRED_DOCUMENT_FIELDS = [Pages, Tokens]
+    REQUIRED_DOCUMENT_FIELDS = [Pages, Tokens]  # type: ignore
 
     def __init__(self) -> None:
 
-        self._segmenter = pysbd.Segmenter(language="en", clean=False, char_span=True)
+        self._segmenter = pysbd.Segmenter(
+            language="en", clean=False, char_span=True)
 
     def split_token_based_on_sentences_boundary(
         self, words: List[str]
     ) -> List[Tuple[int, int]]:
         """
-        Split a list of words into a list of (start, end) indices, indicating the start and end of each sentence.
-        Duplicate of https://github.com/allenai/VILA/blob/dd242d2fcbc5fdcf05013174acadb2dc896a28c3/src/vila/dataset/preprocessors/layout_indicator.py#L14
+        Split a list of words into a list of (start, end) indices, indicating
+        the start and end of each sentence.
+        Duplicate of https://github.com/allenai/VILA/\blob/dd242d2fcbc5fdcf05013174acadb2dc896a28c3/src/vila/dataset/preprocessors/layout_indicator.py#L14      # noqa: E501
 
         Returns: List[Tuple(int, int)]
             a list of (start, end) for token indices within each sentence
@@ -93,12 +96,12 @@ class PysbdSentenceBoundaryPredictor(BaseHeuristicPredictor):
             return [(0, 0)]
         combined_words = " ".join(words)
 
-        char2token_mask = np.zeros(len(combined_words), dtype=np.int)
+        char2token_mask = np.zeros(len(combined_words), dtype=np.int64)
 
         acc_word_len = 0
         for idx, word in enumerate(words):
             word_len = len(word) + 1
-            char2token_mask[acc_word_len : acc_word_len + word_len] = idx
+            char2token_mask[acc_word_len: acc_word_len + word_len] = idx
             acc_word_len += word_len
 
         segmented_sentences = self._segmenter.segment(combined_words)
@@ -120,12 +123,19 @@ class PysbdSentenceBoundaryPredictor(BaseHeuristicPredictor):
     def predict(self, doc: Document) -> List[SpanGroup]:
 
         if hasattr(doc, Words):
-            words = [word.symbols[0] for word in getattr(doc, Words)]
+            words = [
+                # if available, we use the text representation of a word;
+                # if not, we concatenate symbols of in the word instead.
+                (word.text or ''.join(word.symbols))
+                for word in getattr(doc, Words)
+            ]
             attr_name = Words
             # `words` is preferred as it should has better reading
             # orders and text representation
         else:
-            words = [token.symbols[0] for token in doc.tokens]
+            # tokens don't have text representation, so we always
+            # concatenate symbols instead.
+            words = [''.join(token.symbols) for token in doc.tokens]
             attr_name = Tokens
 
         split = self.split_token_based_on_sentences_boundary(words)
@@ -143,6 +153,8 @@ class PysbdSentenceBoundaryPredictor(BaseHeuristicPredictor):
                 itertools.chain.from_iterable([ele.spans for ele in cur_spans])
             )
 
-            sentence_spans.append(SpanGroup(merge_neighbor_spans(all_token_spans)))
+            sentence_spans.append(
+                SpanGroup(spans=merge_neighbor_spans(all_token_spans))
+            )
 
         return sentence_spans


### PR DESCRIPTION
As title suggests, this PR fixes a significant bug that resulted in sentences not being properly created. The issue was due to the fact that merged spans were incorrectly parsed as a uuid instead of span attribute when creating a `SpanGroup` object.

Beside the fix for the bug above, this PR also adds better handling of words when performing sentence segmentation: now, instead of using just the first symbol of a word/token, it uses the text attribute when available, and joins all symbols when not available.