### PR TITLE
Kylel/2022 09/span group utils

### DIFF
--- a/mmda/utils/tools.py
+++ b/mmda/utils/tools.py
@@ -1,10 +1,9 @@
-from typing import List, Union, Dict, Any, Tuple
+from typing import List, Union, Dict, Any, Tuple, Optional
 
 from mmda.types.span import Span
-from mmda.types.box import Box
 
 
-def merge_neighbor_spans(spans: List[Span], distance) -> List[Span]:
+def merge_neighbor_spans(spans: List[Span], distance: Optional[int]) -> List[Span]:
     """Merge neighboring spans in a list of un-overlapped spans:
     when the gaps between neighboring spans is not larger than the
     specified distance, they are considered as the neighbors.
@@ -50,16 +49,6 @@ def merge_neighbor_spans(spans: List[Span], distance) -> List[Span]:
             cur_merged_spans.extend([prev_span, cur_span])
 
     return cur_merged_spans
-
-
-def find_overlapping_tokens_for_box(token_spans: List[Span], box: Box) -> List[Span]:
-    """Retrun a list of spans where their boxes overlap with the input box."""
-
-    return [
-        token
-        for token in token_spans
-        if token.box is not None and token.box.is_overlap(box)
-    ]
 
 
 def allocate_overlapping_tokens_for_box(

--- a/mmda/utils/tools.py
+++ b/mmda/utils/tools.py
@@ -3,7 +3,7 @@ from typing import List, Union, Dict, Any, Tuple, Optional
 from mmda.types.span import Span
 
 
-def merge_neighbor_spans(spans: List[Span], distance: Optional[int]) -> List[Span]:
+def merge_neighbor_spans(spans: List[Span], distance: int) -> List[Span]:
     """Merge neighboring spans in a list of un-overlapped spans:
     when the gaps between neighboring spans is not larger than the
     specified distance, they are considered as the neighbors.

--- a/tests/test_utils/test_tools.py
+++ b/tests/test_utils/test_tools.py
@@ -1,0 +1,65 @@
+"""
+
+
+@kylel
+
+"""
+
+
+import unittest
+
+from mmda.types.span import Span
+from mmda.types.box import Box
+from mmda.utils.tools import merge_neighbor_spans
+
+
+class TestMergeNeighborSpans(unittest.TestCase):
+    def test_merge_multiple_neighbor_spans(self):
+        spans = [Span(start=0, end=10), Span(start=11, end=20), Span(start=21, end=30)]
+        out = merge_neighbor_spans(spans=spans, distance=1)
+        assert len(out) == 1
+        assert isinstance(out[0], Span)
+        assert out[0].start == 0
+        assert out[0].end == 30
+
+    def test_different_distances(self):
+        spans = [Span(start=0, end=10), Span(start=15, end=20)]
+        out = merge_neighbor_spans(spans=spans, distance=1)
+        assert out == spans  # no merge happened
+
+        out = merge_neighbor_spans(spans=spans, distance=2)
+        assert out == spans  # no merge happened
+
+        out = merge_neighbor_spans(spans=spans, distance=4)
+        assert out == spans  # no merge happened
+
+        out = merge_neighbor_spans(spans=spans, distance=5)
+        assert len(out) == 1
+        assert isinstance(out[0], Span)
+        assert out[0].start == 0
+        assert out[0].end == 20
+
+    def test_zero_distance(self):
+        spans = [Span(start=0, end=10), Span(start=10, end=20)]
+        out = merge_neighbor_spans(spans=spans, distance=0)
+        assert len(out) == 1
+        assert isinstance(out[0], Span)
+        assert out[0].start == 0
+        assert out[0].end == 20
+
+    def test_handling_of_boxes(self):
+        spans = [
+            Span(start=0, end=10, box=Box(l=0, t=0, w=1, h=1, page=0)),
+            Span(start=11, end=20, box=Box(l=1, t=1, w=2, h=2, page=1)),
+            Span(start=100, end=150, box=Box(l=2, t=2, w=3, h=3, page=2))
+        ]
+        out = merge_neighbor_spans(spans=spans, distance=1)
+        assert len(out) == 2
+        assert isinstance(out[0], Span)
+        assert isinstance(out[1], Span)
+        assert out[0].start == 0
+        assert out[0].end == 20
+        assert out[1].start == 100
+        assert out[1].end == 150
+        assert out[0].box is None
+        assert out[1].box == spans[-1].box  # unmerged spans keep their original box


### PR DESCRIPTION
minor PR: added tests for a pretty important functionality that was being used -- how to combine Spans that are next to each other into a single big Span.  the key thing that was undocumented was that Boxes for the underlying Spans actually disappear after this merging functionality, which the tests now capture.

dont think this is intended behavior we want to support in future, but for now, this is how this utility is being used