### PR TITLE
Allows empty annotations.

### DIFF
--- a/mmda/types/document.py
+++ b/mmda/types/document.py
@@ -72,7 +72,7 @@ class Document:
             if len(annotations) == 0:
                 warnings.warn(f"The annotations is empty for the field {field_name}")
                 setattr(self, field_name, [])
-                self._fields.append(field_name)
+                self.__fields.append(field_name)
                 continue
 
             annotation_types = {type(a) for a in annotations}

--- a/mmda/types/document.py
+++ b/mmda/types/document.py
@@ -62,7 +62,7 @@ class Document:
                 raise AssertionError(
                     f"The field_name {field_name} should not conflict with existing class properties"
                 )
-                
+
         # Kyle's preserved comment:
         # Is it worth deepcopying the annotations? Safer, but adds ~10%
         # overhead on large documents.
@@ -71,6 +71,8 @@ class Document:
         for field_name, annotations in kwargs.items():
             if len(annotations) == 0:
                 warnings.warn(f"The annotations is empty for the field {field_name}")
+                setattr(self, field_name, [])
+                self._fields.append(field_name)
                 continue
 
             annotation_types = {type(a) for a in annotations}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_namespace_packages, setup
 setup(
     name="mmda",
     description="mmda",
-    version="0.0.40",
+    version="0.0.41",
     url="https://www.github.com/allenai/mmda",
     python_requires=">= 3.7",
     packages=find_namespace_packages(include=["mmda*", "ai2_internal*"]),

--- a/tests/test_types/test_document.py
+++ b/tests/test_types/test_document.py
@@ -1,0 +1,11 @@
+import unittest
+
+from mmda.types.document import Document
+
+
+class TestDocument(unittest.TestCase):
+    def test__empty_annotations_work(self):
+        doc = Document("This is a test document!")
+        annotations = []
+        doc.annotate(my_cool_field=annotations)
+        self.assertEqual(doc.my_cool_field, [])


### PR DESCRIPTION
Previously we would skip making attrs
on the document to represent these empty
annotation groups. This resulted in attr
not found errors in contexts where an expected
field was absent and legitimately empty.