### PR TITLE
Add metadata to API data classes

### DIFF
--- a/ai2_internal/api.py
+++ b/ai2_internal/api.py
@@ -1,10 +1,8 @@
-from __future__ import annotations
+from typing import List, Optional, Type
 
-from typing import List, Optional
 from pydantic import BaseModel
 
 import mmda.types.annotation as mmda_ann
-
 
 __all__ = ["BoxGroup", "SpanGroup"]
 
@@ -17,14 +15,18 @@ class Box(BaseModel):
     page: int
 
     @classmethod
-    def from_mmda(cls, box: mmda_ann.Box) -> Box:
+    def from_mmda(cls, box: mmda_ann.Box) -> "Box":
         return cls(
             left=box.l, top=box.t, width=box.w, height=box.h, page=box.page
         )
 
     def to_mmda(self) -> mmda_ann.Box:
         return mmda_ann.Box(
-            l=self.left, t=self.top, w=self.width, h=self.height, page=self.page
+            l=self.left,
+            t=self.top,
+            w=self.width,
+            h=self.height,
+            page=self.page
         )
 
 
@@ -34,35 +36,72 @@ class Span(BaseModel):
     box: Optional[Box]
 
     @classmethod
-    def from_mmda(cls, span: mmda_ann.Span) -> Span:
-        ret = cls(start=span.start, end=span.end)
+    def from_mmda(cls, span: mmda_ann.Span) -> "Span":
+        box = Box.from_mmda(span.box) if span.box is not None else None
+        ret = cls(start=span.start, end=span.end, box=box)
         if span.box is not None:
             ret.box = Box.from_mmda(span.box)
         return ret
 
     def to_mmda(self) -> mmda_ann.Span:
-        ret = mmda_ann.Span(start=self.start, end=self.end)
-        if self.box is not None:
-            ret.box = self.box.to_mmda()
-        return ret
+        return mmda_ann.Span.from_json(self.dict())
 
 
-class BoxGroup(BaseModel):
+class Metadata(BaseModel):
+    """Class to represent metadata for a SpanGroup or BoxGroup.
+    Unlike mmda.types.annotation.Metadata, this class ignores fields
+    id, type, and text, which are expected to be stored in the SpanGroup
+    / BoxGroup itself."""
+
+    @classmethod
+    def from_mmda(cls, metadata: mmda_ann.Metadata) -> "Metadata":
+        metadata_dict = {
+            k: v
+            for k, v in metadata.to_json().items()
+            if k != "id" and k != "type" and k != "text"
+        }
+        print(cls)
+        return cls(**metadata_dict)
+
+    def to_mmda(self) -> mmda_ann.Metadata:
+        return mmda_ann.Metadata.from_json(self.dict())
+
+
+class Annotation(BaseModel):
+    metadata: Metadata
+
+    @classmethod
+    def get_metadata_cls(cls) -> Type[Metadata]:
+        for inherit_cls in cls.mro():
+            if not hasattr(inherit_cls, "__annotations__"):
+                continue
+            if "metadata" in inherit_cls.__annotations__:
+                return inherit_cls.__annotations__["metadata"]
+        raise ValueError(
+            'No "metadata" annotation found in inheritance hierarchy'
+        )
+
+
+class BoxGroup(Annotation):
     boxes: List[Box]
     id: Optional[int]
     type: Optional[str]
 
     @classmethod
-    def from_mmda(cls, box_group: mmda_ann.BoxGroup) -> BoxGroup:
+    def from_mmda(cls, box_group: mmda_ann.BoxGroup) -> "BoxGroup":
+        # for the Pydantic model, we need to convert the metadata to a dict,
+        # and remove `id` and `type` that are stored there in MMDA
+        # boxes need to be nestedly converted
         boxes = [Box.from_mmda(box) for box in box_group.boxes]
-        return cls(boxes=boxes, id=box_group.id, type=box_group.type)
+        metadata = cls.get_metadata_cls().from_mmda(box_group.metadata)
+
+        return cls(boxes=boxes, id=box_group.id, type=box_group.type, metadata=metadata)
 
     def to_mmda(self) -> mmda_ann.BoxGroup:
-        boxes = [box.to_mmda() for box in self.boxes]
-        return mmda_ann.BoxGroup(boxes=boxes, id=self.id, type=self.type)
+        return mmda_ann.BoxGroup.from_json(self.dict())
 
 
-class SpanGroup(BaseModel):
+class SpanGroup(Annotation):
     spans: List[Span]
     box_group: Optional[BoxGroup]
     id: Optional[int]
@@ -70,24 +109,26 @@ class SpanGroup(BaseModel):
     text: Optional[str]
 
     @classmethod
-    def from_mmda(cls, span_group: mmda_ann.SpanGroup) -> SpanGroup:
+    def from_mmda(cls, span_group: mmda_ann.SpanGroup) -> "SpanGroup":
+        box_group = (
+            BoxGroup.from_mmda(span_group.box_group)
+            if span_group.box_group is not None
+            else None
+        )
+        spans = [Span.from_mmda(sp) for sp in span_group.spans]
+        metadata = cls.get_metadata_cls().from_mmda(span_group.metadata)
+
         ret = cls(
-            spans=[Span.from_mmda(sp) for sp in span_group.spans],
+            spans=spans,
+            box_group=box_group,
             id=span_group.id,
             type=span_group.type,
-            text=span_group.text
+            text=span_group.text,
+            metadata=metadata,
         )
         if span_group.box_group is not None:
             ret.box_group = BoxGroup.from_mmda(span_group.box_group)
         return ret
 
     def to_mmda(self) -> mmda_ann.SpanGroup:
-        ret = mmda_ann.SpanGroup(
-            spans=[sp.to_mmda() for sp in self.spans],
-            id=self.id,
-            type=self.type,
-            text=self.text
-        )
-        if self.box_group is not None:
-            ret.box_group = self.box_group.to_mmda()
-        return ret
+        return mmda_ann.SpanGroup.from_json(self.dict())

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_namespace_packages, setup
 setup(
     name="mmda",
     description="mmda",
-    version="0.0.42",
+    version="0.0.43",
     url="https://www.github.com/allenai/mmda",
     python_requires=">= 3.7",
     packages=find_namespace_packages(include=["mmda*", "ai2_internal*"]),

--- a/tests/test_internal_ai2/test_api.py
+++ b/tests/test_internal_ai2/test_api.py
@@ -1,0 +1,58 @@
+import unittest
+
+from pydantic.error_wrappers import ValidationError
+
+import ai2_internal.api as mmda_api
+import mmda.types.annotation as mmda_ann
+
+
+class ClassificationMetadata(mmda_api.Metadata):
+    label: str
+    score: float
+
+
+class ClassificationSpanGroup(mmda_api.SpanGroup):
+    metadata: ClassificationMetadata
+
+
+class TestApi(unittest.TestCase):
+    def test_vanilla_span_group(self) -> None:
+        sg_ann = mmda_ann.SpanGroup.from_json({
+            'spans': [{'start': 0, 'end': 1}],
+            'metadata': {'text': 'hello', 'id': 1}
+        })
+
+        sg_api = mmda_api.SpanGroup.from_mmda(sg_ann)
+
+        self.assertEqual(sg_api.text, 'hello')
+        self.assertEqual(sg_api.id, 1)
+        self.assertEqual(sg_api.metadata.dict(), {})
+
+    def test_classification_span_group(self) -> None:
+        sg_ann = mmda_ann.SpanGroup.from_json({
+            'spans': [{'start': 0, 'end': 1}],
+            'metadata': {'text': 'hello', 'id': 1}
+        })
+
+        with self.assertRaises(ValidationError):
+            # this should fail because metadata is missing label and confidence
+            ClassificationSpanGroup.from_mmda(sg_ann)
+
+        sg_ann.metadata.label = 'label'
+        sg_ann.metadata.score = 0.5
+
+        sg_api = ClassificationSpanGroup.from_mmda(sg_ann)
+        self.assertEqual(
+            sg_api.metadata.dict(), {'label': 'label', 'score': 0.5}
+        )
+
+        # extra field should just get ignored
+        sg_ann.metadata.extra = 'extra'
+        self.assertEqual(
+            sg_api.metadata.dict(), {'label': 'label', 'score': 0.5}
+        )
+
+        with self.assertRaises(ValidationError):
+            # this should fail bc score is not a float
+            sg_ann.metadata.score = 'not a float'
+            ClassificationSpanGroup.from_mmda(sg_ann)


### PR DESCRIPTION
This PR adds metadata to API data classes. 

API data classes and mmda types differ in a few significant aspects:

- `id` and `type` (and `text` for `SpanGroup`)  are stored in `metadata` for mmda types; in the APIs, they are part of the top-level attributes. 
- `metadata` can store arbitrary content in the mmda types; in the data API, all attributes that are not explicitly declared are dropped. 
    - we expect applications that require specific fields to declare custom Metadata and SpanGroup/BoxGroup classes that inherit from their parent class. For an example, see tests/test_internal_ai2/test_api.py