### PR TITLE
Kylel/2022 10/hotfix mention detection

### DIFF
--- a/mmda/predictors/hf_predictors/mention_predictor.py
+++ b/mmda/predictors/hf_predictors/mention_predictor.py
@@ -81,7 +81,7 @@ class MentionPredictor:
 
         ret = []
         words: List[str] = ["".join(token.symbols) for token in page.tokens]
-        word_spans: List[List[Span]] = [token.spans for token in page.tokens]
+        word_spans: List[List[Span]] = [[Span.from_json(span_dict=span.to_json()) for span in token.spans] for token in page.tokens]
 
         inputs = self.tokenizer(
             [words],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_namespace_packages, setup
 setup(
     name="mmda",
     description="mmda",
-    version="0.0.46",
+    version="0.0.47",
     url="https://www.github.com/allenai/mmda",
     python_requires=">= 3.7",
     packages=find_namespace_packages(include=["mmda*", "ai2_internal*"]),


### PR DESCRIPTION
should fix the issue where `MentionPredictor` was mutating fields in the document. See code below; the final Assertion failed prior to this PR.

Consequence of this is that we would observe `doc.tokens` where the `token` is very long (e.g. `token == 'Yang et al'`) instead of just `token == 'Yang'`)

```
# reproducing error in citations
pdfpath = '/Users/kylel/ai2/mmda/data/from_bailey/121e30c48546e671dc5e16c694c5e69b392cf8fb.pdf'

# parse PDF
doc = parser.parse(input_pdf_path=pdfpath)
tokens1 = [''.join(t.symbols) for t in doc.tokens]

# images
images = rasterizer.rasterize(input_pdf_path=pdfpath, dpi=72)
doc.annotate_images(images=images)
tokens2 = [''.join(t.symbols) for t in doc.tokens]

# boxes
box_groups = vision_predictor.predict(document=doc)
doc.annotate(blocks=box_groups)
tokens3 = [''.join(t.symbols) for t in doc.tokens]

# run vila
vila_preds = vila_predictor.predict(document=doc)
doc.annotate(vila_preds=vila_preds)
tokens4 = [''.join(t.symbols) for t in doc.tokens]

# detect citations
mention_preds = mention_predictor.predict(doc=doc)
doc.annotate(mention_preds=mention_preds)
tokens5 = [''.join(t.symbols) for t in doc.tokens]

assert tokens1 == tokens2, f'1 != 2'
assert tokens1 == tokens3, f'1 != 3'
assert tokens1 == tokens4, f"1 != 4"
assert tokens1 == tokens5, f"1 != 5"
```