### PR TITLE
Kylel/2022 10/hotfix spacing in pdfplumber symbols

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_namespace_packages, setup
 setup(
     name="mmda",
     description="mmda",
-    version="0.0.47",
+    version="0.0.48",
     url="https://www.github.com/allenai/mmda",
     python_requires=">= 3.7",
     packages=find_namespace_packages(include=["mmda*", "ai2_internal*"]),

--- a/tests/test_parsers/test_pdf_plumber_parser.py
+++ b/tests/test_parsers/test_pdf_plumber_parser.py
@@ -1,3 +1,8 @@
+"""
+
+@kylel
+"""
+
 import os
 import pathlib
 import unittest
@@ -6,6 +11,7 @@ from mmda.types import Document
 from mmda.parsers import PDFPlumberParser
 
 import re
+
 
 os.chdir(pathlib.Path(__file__).parent)
 
@@ -49,3 +55,51 @@ class TestPDFPlumberParser(unittest.TestCase):
 
         assert len(no_split_tokens_with_numbers) < len(custom_split_tokens_with_numbers) < len(default_split_tokens_with_numbers)
 
+
+    def test_align_coarse_and_fine_tokens(self):
+        parser = PDFPlumberParser()
+
+        # example
+        coarse_tokens = ['abc', 'def']
+        fine_tokens = ['ab', 'c', 'd', 'ef']
+        out = parser._align_coarse_and_fine_tokens(
+            coarse_tokens=coarse_tokens,
+            fine_tokens=fine_tokens
+        )
+        assert out == [0, 0, 1, 1]
+
+        # minimal case
+        coarse_tokens = []
+        fine_tokens = []
+        out = parser._align_coarse_and_fine_tokens(
+            coarse_tokens=coarse_tokens,
+            fine_tokens=fine_tokens
+        )
+        assert out == []
+
+        # identical case
+        coarse_tokens = ['a', 'b', 'c']
+        fine_tokens = ['a', 'b', 'c']
+        out = parser._align_coarse_and_fine_tokens(
+            coarse_tokens=coarse_tokens,
+            fine_tokens=fine_tokens
+        )
+        assert out == [0, 1, 2]
+
+        # misaligned case
+        with self.assertRaises(AssertionError):
+            coarse_tokens = ['a', 'b']
+            fine_tokens = ['ab']
+            parser._align_coarse_and_fine_tokens(
+                coarse_tokens=coarse_tokens,
+                fine_tokens=fine_tokens
+            )
+
+        # same num of chars, but chars mismatch case
+        with self.assertRaises(AssertionError):
+            coarse_tokens = ['ab']
+            fine_tokens = ['a', 'c']
+            parser._align_coarse_and_fine_tokens(
+                coarse_tokens=coarse_tokens,
+                fine_tokens=fine_tokens
+            )

--- a/tests/test_parsers/test_pdf_plumber_parser.py
+++ b/tests/test_parsers/test_pdf_plumber_parser.py
@@ -7,7 +7,7 @@ import os
 import pathlib
 import unittest
 
-from mmda.types import Document
+from mmda.types import Document, SpanGroup, BoxGroup, Span, Box
 from mmda.parsers import PDFPlumberParser
 
 import re
@@ -103,3 +103,27 @@ class TestPDFPlumberParser(unittest.TestCase):
                 coarse_tokens=coarse_tokens,
                 fine_tokens=fine_tokens
             )
+
+    def test_convert_nested_text_to_doc_json(self):
+        parser = PDFPlumberParser()
+
+        # example
+        token_dicts = [
+            {'text': text, 'bbox': Box(l=0.0, t=0.1, w=0.2, h=0.3, page=4)}
+            for text in ['ab', 'c', 'd', 'ef']
+        ]
+        word_ids = [0, 0, 1, 2]
+        row_ids = [0, 0, 1, 1]
+        out = parser._convert_nested_text_to_doc_json(
+            token_dicts=token_dicts,
+            word_ids=word_ids,
+            row_ids=row_ids
+        )
+        assert out['symbols'] == 'abc\nd ef'
+        tokens = [SpanGroup.from_json(span_group_dict=t_dict) for t_dict in out['tokens']]
+        assert [(t.start, t.end) for t in tokens] == [(0, 2), (2, 3), (4, 5), (6, 8)]
+        assert [out['symbols'][t.start : t.end] for t in tokens] == ['ab', 'c', 'd', 'ef']
+        rows = [SpanGroup.from_json(span_group_dict=r_dict) for r_dict in out['rows']]
+        assert [(r.start, r.end) for r in rows] == [(0, 2), (4, 8)]
+        assert [out['symbols'][r.start: r.end] for r in rows] == ['ab', 'd ef']
+

--- a/tests/test_parsers/test_pdf_plumber_parser.py
+++ b/tests/test_parsers/test_pdf_plumber_parser.py
@@ -110,20 +110,25 @@ class TestPDFPlumberParser(unittest.TestCase):
         # example
         token_dicts = [
             {'text': text, 'bbox': Box(l=0.0, t=0.1, w=0.2, h=0.3, page=4)}
-            for text in ['ab', 'c', 'd', 'ef']
+            for text in ['ab', 'c', 'd', 'ef', 'gh', 'i', 'j', 'kl']
         ]
-        word_ids = [0, 0, 1, 2]
-        row_ids = [0, 0, 1, 1]
+        word_ids = [0, 0, 1, 2, 3, 4, 5, 5]
+        row_ids = [0, 0, 1, 1, 2, 2, 3, 3]
+        page_ids = [0, 0, 0, 0, 1, 1, 1, 1]
         out = parser._convert_nested_text_to_doc_json(
             token_dicts=token_dicts,
             word_ids=word_ids,
-            row_ids=row_ids
+            row_ids=row_ids,
+            page_ids=page_ids
         )
-        assert out['symbols'] == 'abc\nd ef'
+        assert out['symbols'] == 'abc\nd ef\ngh i\njkl'
         tokens = [SpanGroup.from_json(span_group_dict=t_dict) for t_dict in out['tokens']]
-        assert [(t.start, t.end) for t in tokens] == [(0, 2), (2, 3), (4, 5), (6, 8)]
-        assert [out['symbols'][t.start : t.end] for t in tokens] == ['ab', 'c', 'd', 'ef']
+        assert [(t.start, t.end) for t in tokens] == [(0, 2), (2, 3), (4, 5), (6, 8), (9, 11), (12, 13), (14, 15), (15, 17)]
+        assert [out['symbols'][t.start : t.end] for t in tokens] == ['ab', 'c', 'd', 'ef', 'gh', 'i', 'j', 'kl']
         rows = [SpanGroup.from_json(span_group_dict=r_dict) for r_dict in out['rows']]
-        assert [(r.start, r.end) for r in rows] == [(0, 2), (4, 8)]
-        assert [out['symbols'][r.start: r.end] for r in rows] == ['ab', 'd ef']
+        assert [(r.start, r.end) for r in rows] == [(0, 3), (4, 8), (9, 13), (14, 17)]
+        assert [out['symbols'][r.start: r.end] for r in rows] == ['abc', 'd ef', 'gh i', 'jkl']
+        pages = [SpanGroup.from_json(span_group_dict=p_dict) for p_dict in out['pages']]
+        assert [(p.start, p.end) for p in pages] == [(0, 8), (9, 17)]
+        assert [out['symbols'][p.start: p.end] for p in pages] == ['abc\nd ef', 'gh i\njkl']
 


### PR DESCRIPTION
Before, due to tokenization from PDF Plumber that would split on every punctuation, we were observing Documents contained symbols that looked like:
```
>> doc.symbols:
References Mitchell P . Marcus , Beatrice Santorini , and Mary Ann Marcinkiewicz . 1993 .

>> doc.tokens:
References
Mitchell
P
.
Marcus
,
Beatrice
Santorini
,
and
Mary
Ann
Marcinkiewicz
.
1993
.
```

This is because the way PDFPlumberParser constructs `.symbols` to include in Document was previously using either whitespace `" "` or newline `"\n"` concatenation of the strings in each detected token.

What we actually want is to keep this fine-grained partitioning of tokens, but to still have `.symbols` better preserve the  (lack of) whitespacing that exists in the original document, when appropriate. Ideally:

```
>> doc.symbols:
References Mitchell P. Marcus, Beatrice Santorini, and Mary Ann Marcinkiewicz. 1993.

>> doc.tokens:
References
Mitchell
P
.
Marcus
,
Beatrice
Santorini
,
and
Mary
Ann
Marcinkiewicz
.
1993
.
```


This fix is a reimplementation of the logic of how `PDFPlumberParser` pulls information out of `PDFPlumber` objects for stitching together.  The implementation is a bit tricky to explain, but see the new tests to get a sense of functionality.