### PR TITLE
Add Metadata as a top-level Document object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.2.0'
+version = '0.2.1'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/src/mmda/parsers/pdfplumber_parser.py
+++ b/src/mmda/parsers/pdfplumber_parser.py
@@ -9,7 +9,7 @@ from mmda.types.box import Box
 from mmda.types.annotation import SpanGroup
 from mmda.types.document import Document
 from mmda.parsers.parser import Parser
-from mmda.types.names import *
+from mmda.types.names import Pages, Rows, Symbols, Tokens
 
 
 class PDFPlumberParser(Parser):

--- a/src/mmda/parsers/pdfplumber_parser.py
+++ b/src/mmda/parsers/pdfplumber_parser.py
@@ -9,7 +9,7 @@ from mmda.types.box import Box
 from mmda.types.annotation import SpanGroup
 from mmda.types.document import Document
 from mmda.parsers.parser import Parser
-from mmda.types.names import Pages, Rows, Symbols, Tokens
+from mmda.types.names import PagesField, RowsField, SymbolsField, TokensField
 
 
 class PDFPlumberParser(Parser):
@@ -267,10 +267,10 @@ class PDFPlumberParser(Parser):
             page_annos.append(page)
 
         return {
-            Symbols: symbols,
-            Tokens: [token.to_json() for token in token_annos],
-            Rows: [row.to_json() for row in row_annos],
-            Pages: [page.to_json() for page in page_annos]
+            SymbolsField: symbols,
+            TokensField: [token.to_json() for token in token_annos],
+            RowsField: [row.to_json() for row in row_annos],
+            PagesField: [page.to_json() for page in page_annos]
         }
 
     def _simple_line_detection(

--- a/src/mmda/parsers/symbol_scraper_parser.py
+++ b/src/mmda/parsers/symbol_scraper_parser.py
@@ -21,7 +21,7 @@ from mmda.types.box import Box
 from mmda.types.annotation import SpanGroup
 from mmda.types.document import Document
 from mmda.parsers.parser import Parser
-from mmda.types.names import *
+from mmda.types.names import Pages, Rows, Symbols, Tokens
 
 
 logger = logging.getLogger(__name__)

--- a/src/mmda/parsers/symbol_scraper_parser.py
+++ b/src/mmda/parsers/symbol_scraper_parser.py
@@ -21,7 +21,7 @@ from mmda.types.box import Box
 from mmda.types.annotation import SpanGroup
 from mmda.types.document import Document
 from mmda.parsers.parser import Parser
-from mmda.types.names import Pages, Rows, Symbols, Tokens
+from mmda.types.names import PagesField, RowsField, SymbolsField, TokensField
 
 
 logger = logging.getLogger(__name__)
@@ -239,10 +239,10 @@ class SymbolScraperParser(Parser):
         for k, token in enumerate(token_annos):
             token.id = k
         return {
-            Symbols: text,
-            Pages: [page.to_json() for page in page_annos],
-            Tokens: [token.to_json() for token in token_annos],
-            Rows: [row.to_json() for row in row_annos]
+            SymbolsField: text,
+            PagesField: [page.to_json() for page in page_annos],
+            TokensField: [token.to_json() for token in token_annos],
+            RowsField: [row.to_json() for row in row_annos]
         }
 
     def _run_and_log(self, cmd):

--- a/src/mmda/predictors/d2_predictors/bibentry_detection_predictor.py
+++ b/src/mmda/predictors/d2_predictors/bibentry_detection_predictor.py
@@ -8,7 +8,7 @@ from mmda.predictors.base_predictors.base_predictor import BasePredictor
 from mmda.types.annotation import BoxGroup
 from mmda.types.box import Box
 from mmda.types.document import Document
-from mmda.types.names import Pages, Images, Tokens
+from mmda.types.names import PagesField, ImagesField, TokensField
 from mmda.types.span import Span
 
 
@@ -65,7 +65,7 @@ def tighten_boxes(bib_box_group, page_tokens, page_width, page_height):
 
 class BibEntryDetectionPredictor(BasePredictor):
     REQUIRED_BACKENDS = ["layoutparser", "detectron2"]
-    REQUIRED_DOCUMENT_FIELDS = [Pages, Images, Tokens]
+    REQUIRED_DOCUMENT_FIELDS = [PagesField, ImagesField, TokensField]
 
     def __init__(self, artifacts_dir: str, threshold: float = 0.88):
         label_map = {0: "bibentry"}

--- a/src/mmda/predictors/heuristic_predictors/dictionary_word_predictor.py
+++ b/src/mmda/predictors/heuristic_predictors/dictionary_word_predictor.py
@@ -11,13 +11,13 @@ from mmda.predictors.base_predictors.base_predictor import BasePredictor
 from mmda.types.metadata import Metadata
 from mmda.types.annotation import Annotation, Span, SpanGroup
 from mmda.types.document import Document
-from mmda.types.names import Rows, Tokens
+from mmda.types.names import RowsField, TokensField
 
 
 class DictionaryWordPredictor(BasePredictor):
 
     REQUIRED_BACKENDS = None
-    REQUIRED_DOCUMENT_FIELDS = [Rows, Tokens]
+    REQUIRED_DOCUMENT_FIELDS = [RowsField, TokensField]
 
     _dictionary: Optional[Set[str]] = None
 

--- a/src/mmda/predictors/heuristic_predictors/grobid_citation_predictor.py
+++ b/src/mmda/predictors/heuristic_predictors/grobid_citation_predictor.py
@@ -5,17 +5,10 @@
 """
 
 import io
-import os
 import xml.etree.ElementTree as et
-from typing import List, Optional, Text
+from typing import Optional
 
 import requests
-from mmda.parsers.parser import Parser
-from mmda.predictors.base_predictors.base_predictor import BasePredictor
-from mmda.types.annotation import SpanGroup
-from mmda.types.document import Document
-from mmda.types.names import Symbols
-from mmda.types.span import Span
 
 # processCitationList available in Grobid 0.7.1-SNAPSHOT and later
 DEFAULT_API = "http://localhost:8070/api/processCitation"

--- a/src/mmda/predictors/heuristic_predictors/sentence_boundary_predictor.py
+++ b/src/mmda/predictors/heuristic_predictors/sentence_boundary_predictor.py
@@ -7,7 +7,7 @@ import numpy as np
 from mmda.types.annotation import SpanGroup
 from mmda.types.span import Span
 from mmda.types.document import Document
-from mmda.types.names import Pages, Tokens, Words
+from mmda.types.names import PagesField, TokensField, WordsField
 from mmda.predictors.base_predictors.base_heuristic_predictor import (
     BaseHeuristicPredictor,
 )
@@ -73,7 +73,7 @@ class PysbdSentenceBoundaryPredictor(BaseHeuristicPredictor):
     """
 
     REQUIRED_BACKENDS = ["pysbd"]
-    REQUIRED_DOCUMENT_FIELDS = [Pages, Tokens]  # type: ignore
+    REQUIRED_DOCUMENT_FIELDS = [PagesField, TokensField]  # type: ignore
 
     def __init__(self) -> None:
 
@@ -122,16 +122,16 @@ class PysbdSentenceBoundaryPredictor(BaseHeuristicPredictor):
 
     def predict(self, doc: Document) -> List[SpanGroup]:
 
-        if hasattr(doc, Words):
+        if hasattr(doc, WordsField):
             words = [
-                word.text for word in getattr(doc, Words)
+                word.text for word in getattr(doc, WordsField)
             ]
-            attr_name = Words
+            attr_name = WordsField
             # `words` is preferred as it should has better reading
             # orders and text representation
         else:
             words = [token.text for token in doc.tokens]
-            attr_name = Tokens
+            attr_name = TokensField
 
         split = self.split_token_based_on_sentences_boundary(words)
 

--- a/src/mmda/predictors/hf_predictors/token_classification_predictor.py
+++ b/src/mmda/predictors/hf_predictors/token_classification_predictor.py
@@ -9,10 +9,10 @@ from vila.predictors import (
 )
 
 
-from mmda.types.names import *
+from mmda.types.metadata import Metadata as MetadataDict
+from mmda.types.names import Blocks, Pages, Rows, Tokens
 from mmda.types.annotation import Annotation, Span, SpanGroup
 from mmda.types.document import Document
-from mmda.types.metadata import Metadata
 from mmda.predictors.hf_predictors.utils import (
     convert_document_page_to_pdf_dict,
     convert_sequence_tagging_to_spans,
@@ -107,7 +107,7 @@ class BaseSinglePageTokenClassificationPredictor(BaseHFPredictor):
 
             start = min([ele.start for ele in cur_spans])
             end = max([ele.end for ele in cur_spans])
-            sg = SpanGroup(spans=[Span(start, end)], metadata=Metadata(type=label))
+            sg = SpanGroup(spans=[Span(start, end)], metadata=MetadataDict(type=label))
             prediction_spans.append(sg)
         return prediction_spans
 

--- a/src/mmda/predictors/hf_predictors/token_classification_predictor.py
+++ b/src/mmda/predictors/hf_predictors/token_classification_predictor.py
@@ -9,8 +9,8 @@ from vila.predictors import (
 )
 
 
-from mmda.types.metadata import Metadata as MetadataDict
-from mmda.types.names import Blocks, Pages, Rows, Tokens
+from mmda.types.metadata import Metadata
+from mmda.types.names import BlocksField, PagesField, RowsField, TokensField
 from mmda.types.annotation import Annotation, Span, SpanGroup
 from mmda.types.document import Document
 from mmda.predictors.hf_predictors.utils import (
@@ -22,7 +22,7 @@ from mmda.predictors.hf_predictors.base_hf_predictor import BaseHFPredictor
 
 class BaseSinglePageTokenClassificationPredictor(BaseHFPredictor):
     REQUIRED_BACKENDS = ["transformers", "torch", "vila"]
-    REQUIRED_DOCUMENT_FIELDS = [Pages, Tokens]
+    REQUIRED_DOCUMENT_FIELDS = [PagesField, TokensField]
     DEFAULT_SUBPAGE_PER_RUN = 2  # TODO: Might remove this in the future for longformer-like models
 
     @property
@@ -107,7 +107,7 @@ class BaseSinglePageTokenClassificationPredictor(BaseHFPredictor):
 
             start = min([ele.start for ele in cur_spans])
             end = max([ele.end for ele in cur_spans])
-            sg = SpanGroup(spans=[Span(start, end)], metadata=MetadataDict(type=label))
+            sg = SpanGroup(spans=[Span(start, end)], metadata=Metadata(type=label))
             prediction_spans.append(sg)
         return prediction_spans
 
@@ -123,11 +123,11 @@ class IVILATokenClassificationPredictor(BaseSinglePageTokenClassificationPredict
 
     @property
     def REQUIRED_DOCUMENT_FIELDS(self) -> List:
-        base_reqs = [Pages, Tokens]
+        base_reqs = [PagesField, TokensField]
         if self.predictor.preprocessor.config.agg_level == "row":
-            base_reqs.append(Rows)
+            base_reqs.append(RowsField)
         elif self.predictor.preprocessor.config.agg_level == "block":
-            base_reqs.append(Blocks)
+            base_reqs.append(BlocksField)
         return base_reqs
 
 
@@ -136,10 +136,10 @@ class HVILATokenClassificationPredictor(BaseSinglePageTokenClassificationPredict
 
     @property
     def REQUIRED_DOCUMENT_FIELDS(self) -> List:
-        base_reqs = [Pages, Tokens]
+        base_reqs = [PagesField, TokensField]
         if self.predictor.preprocessor.config.agg_level == "row":
-            base_reqs.append(Rows)
+            base_reqs.append(RowsField)
         elif self.predictor.preprocessor.config.agg_level == "block":
-            base_reqs.append(Blocks)
+            base_reqs.append(BlocksField)
         return base_reqs
 

--- a/src/mmda/predictors/hf_predictors/utils.py
+++ b/src/mmda/predictors/hf_predictors/utils.py
@@ -3,7 +3,7 @@ from typing import List, Tuple, Dict
 import itertools
 
 from mmda.types.document import Document
-from mmda.types.names import *
+from mmda.types.names import Blocks, Rows
 
 
 def normalize_bbox(

--- a/src/mmda/predictors/hf_predictors/utils.py
+++ b/src/mmda/predictors/hf_predictors/utils.py
@@ -3,7 +3,7 @@ from typing import List, Tuple, Dict
 import itertools
 
 from mmda.types.document import Document
-from mmda.types.names import Blocks, Rows
+from mmda.types.names import BlocksField, RowsField
 
 
 def normalize_bbox(
@@ -84,8 +84,8 @@ def convert_document_page_to_pdf_dict(
             token.spans[0]
                 .box.get_absolute(page_width=page_width, page_height=page_height)
                 .coordinates,  # bbox
-            get_visual_group_id(token, Rows, -1),  # line_ids
-            get_visual_group_id(token, Blocks, -1)  # block_ids
+            get_visual_group_id(token, RowsField, -1),  # line_ids
+            get_visual_group_id(token, BlocksField, -1)  # block_ids
         ) for token in document.tokens
     ]
 

--- a/src/mmda/predictors/hf_predictors/vila_predictor.py
+++ b/src/mmda/predictors/hf_predictors/vila_predictor.py
@@ -17,9 +17,9 @@ from vila.models.hierarchical_model import (
 )
 from vila.dataset.preprocessors import instantiate_dataset_preprocessor
 
-from mmda.types.names import *
+from mmda.types.metadata import Metadata as MetadataDict
+from mmda.types.names import Pages, Rows, Tokens
 from mmda.types.annotation import Annotation, Span, SpanGroup
-from mmda.types.metadata import Metadata
 from mmda.types.document import Document
 from mmda.predictors.hf_predictors.utils import (
     convert_document_page_to_pdf_dict,
@@ -168,7 +168,7 @@ class BaseVILAPredictor(BaseHFPredictor):
 
             start = min([ele.start for ele in cur_spans])
             end = max([ele.end for ele in cur_spans])
-            sg = SpanGroup(spans=[Span(start, end)], metadata=Metadata(type=label))
+            sg = SpanGroup(spans=[Span(start, end)], metadata=MetadataDict(type=label))
             prediction_spans.append(sg)
 
         return prediction_spans

--- a/src/mmda/predictors/hf_predictors/vila_predictor.py
+++ b/src/mmda/predictors/hf_predictors/vila_predictor.py
@@ -17,8 +17,8 @@ from vila.models.hierarchical_model import (
 )
 from vila.dataset.preprocessors import instantiate_dataset_preprocessor
 
-from mmda.types.metadata import Metadata as MetadataDict
-from mmda.types.names import Pages, Rows, Tokens
+from mmda.types.metadata import Metadata
+from mmda.types.names import PagesField, RowsField, TokensField
 from mmda.types.annotation import Annotation, Span, SpanGroup
 from mmda.types.document import Document
 from mmda.predictors.hf_predictors.utils import (
@@ -58,7 +58,7 @@ class VILAPreprocessorConfig:
 class BaseVILAPredictor(BaseHFPredictor):
 
     REQUIRED_BACKENDS = ["transformers", "torch", "vila"]
-    REQUIRED_DOCUMENT_FIELDS = [Pages, Tokens]
+    REQUIRED_DOCUMENT_FIELDS = [PagesField, TokensField]
 
     def __init__(
         self, model: Any, config: Any, tokenizer: Any, preprocessor, device=None
@@ -168,7 +168,7 @@ class BaseVILAPredictor(BaseHFPredictor):
 
             start = min([ele.start for ele in cur_spans])
             end = max([ele.end for ele in cur_spans])
-            sg = SpanGroup(spans=[Span(start, end)], metadata=MetadataDict(type=label))
+            sg = SpanGroup(spans=[Span(start, end)], metadata=Metadata(type=label))
             prediction_spans.append(sg)
 
         return prediction_spans
@@ -214,7 +214,7 @@ class BaseVILAPredictor(BaseHFPredictor):
 
 class SimpleVILAPredictor(BaseVILAPredictor):
 
-    REQUIRED_DOCUMENT_FIELDS = [Pages, Tokens]
+    REQUIRED_DOCUMENT_FIELDS = [PagesField, TokensField]
 
     @staticmethod
     def initialize_preprocessor(tokenizer, config: VILAPreprocessorConfig):
@@ -239,7 +239,7 @@ class SimpleVILAPredictor(BaseVILAPredictor):
 
 
 class IVILAPredictor(SimpleVILAPredictor):
-    REQUIRED_DOCUMENT_FIELDS = [Pages, Tokens, Rows]  # , Blocks]
+    REQUIRED_DOCUMENT_FIELDS = [PagesField, TokensField, RowsField]  # , Blocks]
     # TODO: Right now we only use the rows, but we should also use the blocks
     # in the future.
 
@@ -249,7 +249,7 @@ class IVILAPredictor(SimpleVILAPredictor):
 
 
 class HVILAPredictor(BaseVILAPredictor):
-    REQUIRED_DOCUMENT_FIELDS = [Pages, Tokens, Rows]  # , Blocks]
+    REQUIRED_DOCUMENT_FIELDS = [PagesField, TokensField, RowsField]  # , Blocks]
     # TODO: Right now we only use the rows, but we should also use the blocks
     # in the future.
 

--- a/src/mmda/predictors/lp_predictors.py
+++ b/src/mmda/predictors/lp_predictors.py
@@ -4,7 +4,7 @@ from tqdm import tqdm
 import layoutparser as lp
 
 from mmda.types import Document, Box, BoxGroup, Metadata
-from mmda.types.names import *
+from mmda.types.names import Images, Pages
 from mmda.predictors.base_predictors.base_predictor import BasePredictor
 
 

--- a/src/mmda/predictors/lp_predictors.py
+++ b/src/mmda/predictors/lp_predictors.py
@@ -4,13 +4,13 @@ from tqdm import tqdm
 import layoutparser as lp
 
 from mmda.types import Document, Box, BoxGroup, Metadata
-from mmda.types.names import Images, Pages
+from mmda.types.names import ImagesField, PagesField
 from mmda.predictors.base_predictors.base_predictor import BasePredictor
 
 
 class LayoutParserPredictor(BasePredictor):
     REQUIRED_BACKENDS = ["layoutparser"]
-    REQUIRED_DOCUMENT_FIELDS = [Pages, Images]
+    REQUIRED_DOCUMENT_FIELDS = [PagesField, ImagesField]
 
     def __init__(self, model):
         self.model = model

--- a/src/mmda/predictors/tesseract_predictors.py
+++ b/src/mmda/predictors/tesseract_predictors.py
@@ -9,7 +9,7 @@ from mmda.predictors.base_predictors.base_predictor import BasePredictor
 from mmda.types.annotation import BoxGroup
 from mmda.types.box import Box
 from mmda.types.document import Document
-from mmda.types.names import Images
+from mmda.types.names import ImagesField
 
 
 @dataclass
@@ -46,7 +46,7 @@ class TesseractData:
 
 class TesseractBlockPredictor(BasePredictor):
     REQUIRED_BACKENDS = ["pytesseract"]
-    REQUIRED_DOCUMENT_FIELDS = [Images]
+    REQUIRED_DOCUMENT_FIELDS = [ImagesField]
 
     def predict(self, document: Document) -> Iterable[BoxGroup]:
         box_groups = []

--- a/src/mmda/types/document.py
+++ b/src/mmda/types/document.py
@@ -6,19 +6,19 @@
 
 import itertools
 import warnings
-from copy import deepcopy
 from typing import Dict, Iterable, List, Optional
 
 from mmda.types.annotation import Annotation, BoxGroup, SpanGroup
 from mmda.types.image import PILImage
 from mmda.types.indexers import Indexer, SpanGroupIndexer
-from mmda.types.names import Images, Symbols
-from mmda.utils.tools import allocate_overlapping_tokens_for_box, MergeSpans
+from mmda.types.metadata import Metadata as MetadataDict
+from mmda.types.names import Images, Metadata, Symbols
+from mmda.utils.tools import MergeSpans, allocate_overlapping_tokens_for_box
 
 
 class Document:
 
-    SPECIAL_FIELDS = [Symbols, Images]
+    SPECIAL_FIELDS = [Symbols, Images, Metadata]
     UNALLOWED_FIELD_NAMES = ["fields"]
 
     def __init__(self, symbols: str):
@@ -26,6 +26,7 @@ class Document:
         self.images = []
         self.__fields = []
         self.__indexers: Dict[str, Indexer] = {}
+        self.metadata = MetadataDict()
 
     @property
     def fields(self) -> List[str]:
@@ -38,6 +39,11 @@ class Document:
                 f"Currently only supports query of type SpanGroup"
             )
         return self.__indexers[field_name].find(query=query)
+
+    def add_metadata(self, **kwargs):
+        """Copy kwargs into the document metadata"""
+        for k, value in kwargs.items():
+            self.metadata.set(k, value)
 
     def annotate(
         self, is_overwrite: bool = False, **kwargs: Iterable[Annotation]
@@ -176,8 +182,10 @@ class Document:
 
             derived_span_groups.append(
                 SpanGroup(
-                    spans=MergeSpans(list_of_spans=all_token_spans_with_box_group, index_distance=1)
-                    .merge_neighbor_spans_by_symbol_distance(), box_group=box_group,
+                    spans=MergeSpans(
+                        list_of_spans=all_token_spans_with_box_group, index_distance=1
+                    ).merge_neighbor_spans_by_symbol_distance(),
+                    box_group=box_group,
                     # id = box_id,
                 )
                 # TODO Right now we cannot assign the box id, or otherwise running doc.blocks will
@@ -212,10 +220,11 @@ class Document:
             {
                 symbols: "...",
                 field1: [...],
-                field2: [...]
+                field2: [...],
+                metadata: {...}
             }
         """
-        doc_dict = {Symbols: self.symbols}
+        doc_dict = {Symbols: self.symbols, Metadata: self.metadata.to_json()}
         if with_images:
             doc_dict[Images] = [image.to_json() for image in self.images]
 
@@ -237,6 +246,9 @@ class Document:
         # 1) instantiate basic Document
         symbols = doc_dict[Symbols]
         doc = cls(symbols=symbols)
+
+        if Metadata in doc_dict:
+            doc.add_metadata(**doc_dict[Metadata])
 
         images_dict = doc_dict.get(Images, None)
         if images_dict:

--- a/src/mmda/types/document.py
+++ b/src/mmda/types/document.py
@@ -224,7 +224,7 @@ class Document:
                 metadata: {...}
             }
         """
-        doc_dict = {SymbolsField: self.symbols, Metadata: self.metadata.to_json()}
+        doc_dict = {SymbolsField: self.symbols, MetadataField: self.metadata.to_json()}
         if with_images:
             doc_dict[ImagesField] = [image.to_json() for image in self.images]
 
@@ -245,7 +245,7 @@ class Document:
     def from_json(cls, doc_dict: Dict) -> "Document":
         # 1) instantiate basic Document
         symbols = doc_dict[SymbolsField]
-        doc = cls(symbols=symbols, metadata=Metadata(**doc_dict.get(Metadata, {})))
+        doc = cls(symbols=symbols, metadata=Metadata(**doc_dict.get(MetadataField, {})))
 
         if Metadata in doc_dict:
             doc.add_metadata(**doc_dict[Metadata])

--- a/src/mmda/types/document.py
+++ b/src/mmda/types/document.py
@@ -21,12 +21,12 @@ class Document:
     SPECIAL_FIELDS = [Symbols, Images, Metadata]
     UNALLOWED_FIELD_NAMES = ["fields"]
 
-    def __init__(self, symbols: str):
+    def __init__(self, symbols: str, metadata: Optional[MetadataDict] = None):
         self.symbols = symbols
         self.images = []
         self.__fields = []
         self.__indexers: Dict[str, Indexer] = {}
-        self.metadata = MetadataDict()
+        self.metadata = metadata if metadata else MetadataDict()
 
     @property
     def fields(self) -> List[str]:
@@ -245,7 +245,7 @@ class Document:
     def from_json(cls, doc_dict: Dict) -> "Document":
         # 1) instantiate basic Document
         symbols = doc_dict[Symbols]
-        doc = cls(symbols=symbols)
+        doc = cls(symbols=symbols, metadata=MetadataDict(**doc_dict.get(Metadata, {})))
 
         if Metadata in doc_dict:
             doc.add_metadata(**doc_dict[Metadata])

--- a/src/mmda/types/names.py
+++ b/src/mmda/types/names.py
@@ -7,12 +7,13 @@ Names of fields, as strings
 """
 
 # document field names
-Symbols = 'symbols'
-Images = 'images'
+Symbols = "symbols"
+Metadata = "metadata"
+Images = "images"
 
-Pages = 'pages'
-Tokens = 'tokens'
-Rows = 'rows'
-Sentences = 'sents'
-Blocks = 'blocks'
-Words = 'words'
+Pages = "pages"
+Tokens = "tokens"
+Rows = "rows"
+Sentences = "sents"
+Blocks = "blocks"
+Words = "words"

--- a/src/mmda/types/names.py
+++ b/src/mmda/types/names.py
@@ -7,13 +7,13 @@ Names of fields, as strings
 """
 
 # document field names
-Symbols = "symbols"
-Metadata = "metadata"
-Images = "images"
+SymbolsField = "symbols"
+MetadataField = "metadata"
+ImagesField = "images"
 
-Pages = "pages"
-Tokens = "tokens"
-Rows = "rows"
-Sentences = "sents"
-Blocks = "blocks"
-Words = "words"
+PagesField = "pages"
+TokensField = "tokens"
+RowsField = "rows"
+SentencesField = "sents"
+BlocksField = "blocks"
+WordsField = "words"

--- a/tests/test_parsers/test_override.py
+++ b/tests/test_parsers/test_override.py
@@ -5,7 +5,7 @@ from typing import List
 
 from mmda.types.document import Document
 from mmda.types.annotation import SpanGroup
-from mmda.types.names import Tokens
+from mmda.types.names import TokensField
 from mmda.parsers.pdfplumber_parser import PDFPlumberParser
 from mmda.predictors.base_predictors.base_predictor import BasePredictor
 
@@ -28,7 +28,7 @@ class MockPredictor(BasePredictor):
                 box_group=token.box_group,
                 metadata=token.metadata,
             )
-            for token in getattr(document, Tokens, [])
+            for token in getattr(document, TokensField, [])
         ]
 
 

--- a/tests/test_types/test_document.py
+++ b/tests/test_types/test_document.py
@@ -1,7 +1,7 @@
 import unittest
 
 from mmda.types.document import Document
-from mmda.types.names import Metadata, Symbols
+from mmda.types.names import MetadataField, SymbolsField
 
 
 class TestDocument(unittest.TestCase):
@@ -18,12 +18,14 @@ class TestDocument(unittest.TestCase):
         doc.add_metadata(**metadata)
 
         output_json = doc.to_json()
-        self.assertDictEqual({Symbols: symbols, Metadata: metadata}, output_json)
+        self.assertDictEqual(
+            {SymbolsField: symbols, MetadataField: metadata}, output_json
+        )
 
     def test_metadata_deserializes(self):
         metadata = {"a": {"b": "c"}}
         symbols = "Hey again peeps!"
-        input_json = {Symbols: symbols, Metadata: metadata}
+        input_json = {SymbolsField: symbols, MetadataField: metadata}
 
         doc = Document.from_json(input_json)
 
@@ -32,7 +34,7 @@ class TestDocument(unittest.TestCase):
 
     def test_metadata_deserializes_when_empty(self):
         symbols = "That's all folks!"
-        input_json = {Symbols: symbols}
+        input_json = {SymbolsField: symbols}
 
         doc = Document.from_json(input_json)
 

--- a/tests/test_types/test_document.py
+++ b/tests/test_types/test_document.py
@@ -1,6 +1,7 @@
 import unittest
 
 from mmda.types.document import Document
+from mmda.types.names import Metadata, Symbols
 
 
 class TestDocument(unittest.TestCase):
@@ -9,3 +10,31 @@ class TestDocument(unittest.TestCase):
         annotations = []
         doc.annotate(my_cool_field=annotations)
         self.assertEqual(doc.my_cool_field, [])
+
+    def test_metadata_serializes(self):
+        metadata = {"a": {"b": "c"}}
+        symbols = "Hey there y'all!"
+        doc = Document(symbols=symbols)
+        doc.add_metadata(**metadata)
+
+        output_json = doc.to_json()
+        self.assertDictEqual({Symbols: symbols, Metadata: metadata}, output_json)
+
+    def test_metadata_deserializes(self):
+        metadata = {"a": {"b": "c"}}
+        symbols = "Hey again peeps!"
+        input_json = {Symbols: symbols, Metadata: metadata}
+
+        doc = Document.from_json(input_json)
+
+        self.assertEqual(symbols, doc.symbols)
+        self.assertDictEqual(metadata, doc.metadata.to_json())
+
+    def test_metadata_deserializes_when_empty(self):
+        symbols = "That's all folks!"
+        input_json = {Symbols: symbols}
+
+        doc = Document.from_json(input_json)
+
+        self.assertEqual(symbols, doc.symbols)
+        self.assertEqual(0, len(doc.metadata))


### PR DESCRIPTION
Example use case: Store metadata about the PDF outline (i.e., table of contents sidebar) that doesn't fit perfectly into any of the existing annotation types (BoxGroup or SpanGroup). A PDF outline object is essentially a tuple of (text, location-pointer, nesting-level).

Idea discussed briefly with @kyleclo so this may need refinement.