### PR TITLE
Fixes citation linker and errata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.2.1'
+version = '0.2.2'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},
@@ -108,7 +108,7 @@ bibentry_detection_predictor = [
 citation_links = [
     'numpy',
     'thefuzz[speedup]',
-    'sklearn',
+    'scikit-learn',
     'xgboost',
 ]
 figure_table_predictors = [

--- a/src/ai2_internal/api.py
+++ b/src/ai2_internal/api.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Type
 
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel, Extra, Field
 from pydantic.fields import ModelField
 
 import mmda.types.annotation as mmda_ann
@@ -68,7 +68,7 @@ class Attributes(BaseModel):
 
 
 class Annotation(BaseModel, extra=Extra.ignore):
-    attributes: Attributes
+    attributes: Attributes = Attributes()
 
     @classmethod
     def get_metadata_cls(cls) -> Type[Attributes]:


### PR DESCRIPTION
sklearn is no longer a real package on pypi
and instead was a deprecation timebomb waiting to blow up.
See:
https://pypi.org/project/sklearn/

Must now install as "scikit-learn" for reasons.

* separately provides a default to some new parameter that was added on
  `api.SapnGroup`, as we're not explicitly passing this