### PR TITLE
Kylel/2022 12/debug dwp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.2.5'
+version = '0.2.6'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/tests/test_predictors/test_dictionary_word_predictor.py
+++ b/tests/test_predictors/test_dictionary_word_predictor.py
@@ -1,7 +1,7 @@
 """
 Tests for DictionaryWordPredictor
 
-@rauthur
+@rauthur, @kylel
 """
 
 import tempfile
@@ -166,3 +166,23 @@ class TestDictionaryWordPredictor(unittest.TestCase):
 
         self.assertEqual([w.text for w in words], ['-', '-', 'cdefg'])
 
+
+    def test_words_with_surrounding_punct(self):
+        predictor = DictionaryWordPredictor()
+
+        # simple case without punctuation
+        text = '(abc)'
+        spans = [
+            Span(start=0, end=1),
+            Span(start=1, end=4),
+            Span(start=4, end=5)
+        ]
+        rows = [
+            SpanGroup(id=1, spans=[spans[0]]),
+            SpanGroup(id=2, spans=[spans[1]]),
+            SpanGroup(id=3, spans=[spans[2]]),
+        ]
+        document = mock_document(symbols=text, spans=spans, rows=rows)
+        words = predictor.predict(document)
+
+        self.assertEqual([w.text for w in words], ['(', 'abc', ')'])

--- a/tests/test_predictors/test_dictionary_word_predictor.py
+++ b/tests/test_predictors/test_dictionary_word_predictor.py
@@ -127,3 +127,42 @@ class TestDictionaryWordPredictor(unittest.TestCase):
             words = predictor.predict(document)
 
         self.assertEqual([w.text for w in words], ['Many', 'lin-es'])
+
+
+    def test_single_token_rows(self):
+        predictor = DictionaryWordPredictor()
+
+        # simple case without punctuation
+        text = 'a b cdefg'
+        spans = [
+            Span(start=0, end=1),
+            Span(start=2, end=3),
+            Span(start=4, end=9)
+        ]
+        rows = [
+            SpanGroup(id=1, spans=[spans[0]]),
+            SpanGroup(id=2, spans=[spans[1]]),
+            SpanGroup(id=3, spans=[spans[2]]),
+        ]
+        document = mock_document(symbols=text, spans=spans, rows=rows)
+        words = predictor.predict(document)
+
+        self.assertEqual([w.text for w in words], ['a', 'b', 'cdefg'])
+
+        # now with punctuation
+        text = '- - cdefg'
+        spans = [
+            Span(start=0, end=1),
+            Span(start=2, end=3),
+            Span(start=4, end=9)
+        ]
+        rows = [
+            SpanGroup(id=1, spans=[spans[0]]),
+            SpanGroup(id=2, spans=[spans[1]]),
+            SpanGroup(id=3, spans=[spans[2]]),
+        ]
+        document = mock_document(symbols=text, spans=spans, rows=rows)
+        words = predictor.predict(document)
+
+        self.assertEqual([w.text for w in words], ['-', '-', 'cdefg'])
+


### PR DESCRIPTION
Resolve this issue:

```
 File "/usr/local/lib/python3.8/site-packages/mmda/predictors/heuristic_predictors/dictionary_word_predictor.py", line 149, in predict
    token_id_to_word_id, word_id_to_text = self._predict_tokens(
  File "/usr/local/lib/python3.8/site-packages/mmda/predictors/heuristic_predictors/dictionary_word_predictor.py", line 402, in _predict_tokens
    assert None not in token_id_to_word_id.values()
AssertionError
```

Basically, found singletons with `-` hyphen that were breaking row logic. Those are classified correctly now.