### PR TITLE
Kylel/2022 12/bugfix overlapping spans pdfplumber

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.2.6'
+version = '0.2.7'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
         'pandas',
         'pydantic',
         'ncls',
-        'necessary',
+        'necessary>=0.3.2',
 ]
 
 [project.urls]

--- a/src/mmda/predictors/heuristic_predictors/dictionary_word_predictor.py
+++ b/src/mmda/predictors/heuristic_predictors/dictionary_word_predictor.py
@@ -440,19 +440,21 @@ class DictionaryWordPredictor(BasePredictor):
         # this part identifies words that begin with punctuation, and splits them.
         for token in document.tokens:
             if token.id in punct_l_strip_candidate_token_ids:
-                # current state, before fixing
+                # capture current state, before fixing
                 word_id = token_id_to_word_id[token.id]
                 word_text = word_id_to_text[word_id]
-                # update this punctuation token to be its own word
-                word_id_to_text[word_id] = token.text
-                # update subsequent tokens that were implicated. fix their word_id. fix the text.
                 other_same_word_token_ids = [
                     i for i in word_id_to_token_ids[token_id_to_word_id[token.id]]
                     if token_id_to_word_id[i] == word_id and i != token.id
                 ]
                 new_first_token_id = min(other_same_word_token_ids)
+                # update this punctuation token to be its own word
+                word_id_to_text[word_id] = token.text
+                word_id_to_token_ids[word_id] = [token.id]
+                # update subsequent tokens that were implicated. fix their word_id. fix the text.
                 for other_token_id in other_same_word_token_ids:
                     token_id_to_word_id[other_token_id] = new_first_token_id
+                word_id_to_token_ids[new_first_token_id] = other_same_word_token_ids
                 word_id_to_text[new_first_token_id] = word_text.lstrip(token.text)
         # this data structure has served its purpose by this point
         del word_id_to_token_ids

--- a/tests/test_predictors/test_dictionary_word_predictor.py
+++ b/tests/test_predictors/test_dictionary_word_predictor.py
@@ -186,3 +186,23 @@ class TestDictionaryWordPredictor(unittest.TestCase):
         words = predictor.predict(document)
 
         self.assertEqual([w.text for w in words], ['(', 'abc', ')'])
+
+
+    def test_words_with_multiple_preceding_punct(self):
+        predictor = DictionaryWordPredictor()
+
+        text = ')/2'
+        spans = [
+            Span(start=0, end=1),
+            Span(start=1, end=2),
+            Span(start=2, end=3)
+        ]
+        rows = [
+            SpanGroup(id=1, spans=[spans[0]]),
+            SpanGroup(id=2, spans=[spans[1]]),
+            SpanGroup(id=3, spans=[spans[2]]),
+        ]
+        document = mock_document(symbols=text, spans=spans, rows=rows)
+        words = predictor.predict(document)
+
+        self.assertEqual([w.text for w in words], [')', '/', '2'])


### PR DESCRIPTION
Addressing problems in https://github.com/allenai/scholar/issues/34648. Both PDFs run fine now after this fix + previous version upgrade.

Also upgrade `necessary` which something changed in upstream dependency.