### PR TITLE
Cap PDFPlumber version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = '>=3.7'
 dependencies = [
         'tqdm',
         'pdf2image',
-        'pdfplumber>0.7.1',
+        'pdfplumber>0.7.1,0.8',
         'requests',
         'pandas',
         'pydantic',


### PR DESCRIPTION
cap pdfplumber version since they made 0.8.0 release which moves Word…Extractor to a submodule.

Can see here it's now under a submodule `text`: https://github.com/jsvine/pdfplumber/blob/b6847ad4cd4e54e201c0301f66b2c1f3e914cdc0/pdfplumber/utils/text.py

which didn't exist before in 0.7.6 or earlier versions. We were relying on the WordExtractor from: https://github.com/jsvine/pdfplumber/blob/v0.7.6/pdfplumber/utils.py
