### PR TITLE
TIMO Citation linker returns Relations objects.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.2.82'
+version = '0.2.83'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/src/ai2_internal/api.py
+++ b/src/ai2_internal/api.py
@@ -158,3 +158,9 @@ class SpanGroup(Annotation):
             box_group=self.box_group.to_mmda()if self.box_group else None,
             id=self.id
         )
+
+
+class Relation(BaseModel):
+    from_id: int
+    to_id: int
+    attributes: Attributes = Attributes()

--- a/src/ai2_internal/citation_links/integration_test.py
+++ b/src/ai2_internal/citation_links/integration_test.py
@@ -49,7 +49,7 @@ class TestInterfaceIntegration(unittest.TestCase):
     def test__predictions(self, container):
         # single text string representing text contents of pdf
         symbols = "titlexxxx4xxxx16xxx[16] C. Fisch, Centennial of the string galvanometer and the electro- cardiogram4. Wei Zhuo, Qianyi Zhan, Yuan Liu, Zhenping Xie, and Jing Lu. Context attention heterogeneous network embed- ding.37 Urban Taco Collective, Tacos with sauce, 2019"
-        
+
         # text for this span is "4"
         span1 = api.Span(start = 9, end = 10, box = None)
         mention1 = api.SpanGroup(
@@ -105,12 +105,17 @@ class TestInterfaceIntegration(unittest.TestCase):
             Instance(symbols = symbols, mentions = [mention1, mention2], bibs = [bib1, bib2, bib3])
         ]
 
-        
+
         predictions = container.predict_batch(instances)
         self.assertEqual(len(predictions), 1)
 
-        predicted_links = predictions[0].linked_mentions        
+        predicted_links = predictions[0].linked_mentions
         self.assertEqual(len(predicted_links), 2)
         self.assertEqual(predicted_links[0], (str(mention1.id), str(bib2.id)))
         self.assertEqual(predicted_links[1], (str(mention2.id), str(bib1.id)))
-        
+
+        predicted_relations = predictions[0].linked_mention_relations
+        self.assertEqual(len(predicted_relations), 2)
+        self.assertEqual(predicted_relations[0], api.Relation(from_id=mention1.id, to_id=bib2.id))
+        self.assertEqual(predicted_relations[1], api.Relation(from_id=mention2.id, to_id=bib1.id))
+

--- a/src/ai2_internal/citation_links/interface.py
+++ b/src/ai2_internal/citation_links/interface.py
@@ -31,6 +31,7 @@ class Prediction(BaseModel):
     """
     # tuple represents mention.id and bib.id for the linked pair
     linked_mentions: List[Tuple[str, str]]
+    linked_mention_relations: List[api.Relation]
 
 
 class PredictorConfig(BaseSettings):
@@ -65,9 +66,15 @@ class Predictor:
         doc.annotate(mentions=[sg.to_mmda() for sg in inst.mentions])
         doc.annotate(bibs=[sg.to_mmda() for sg in inst.bibs])
 
-        prediction = self._predictor.predict(doc) # returns (mention.id, bib.id)
-        
-        return Prediction(linked_mentions = prediction)
+        prediction = self._predictor.predict(doc) # returns [(mention.id, bib.id)]
+
+        return Prediction(
+            linked_mentions = prediction,
+            linked_mention_relations = [
+                api.Relation(from_id=mention_id, to_id=bib_id)
+                for mention_id, bib_id in prediction
+            ]
+        )
 
     def predict_batch(self, instances: List[Instance]) -> List[Prediction]:
         """


### PR DESCRIPTION
Purely additive change that has the citation linker
timo predictor return links in the future-standard
generalized `Relation` format.

This is the format expected by clients in new SPP
code.

cc also @geli-gel as this may be relevant for grobid
work