### PR TITLE
Handle no-bibs in citation linker.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.2.83'
+version = '0.2.84'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/src/ai2_internal/citation_links/integration_test.py
+++ b/src/ai2_internal/citation_links/integration_test.py
@@ -44,78 +44,97 @@ except ImportError as e:
     sys.exit(0)
 
 
+# single text string representing text contents of pdf
+SYMBOLS = "titlexxxx4xxxx16xxx[16] C. Fisch, Centennial of the string galvanometer and the electro- cardiogram4. Wei Zhuo, Qianyi Zhan, Yuan Liu, Zhenping Xie, and Jing Lu. Context attention heterogeneous network embed- ding.37 Urban Taco Collective, Tacos with sauce, 2019"
+
+SPAN_1 = api.Span(start = 9, end = 10, box = None)
+MENTION_1 = api.SpanGroup(
+    spans = [SPAN_1],
+    box_group = None,
+    id = 1,
+    type = None,
+    text = None
+)
+
+# text for this span is "16"
+SPAN_2 = api.Span(start = 14, end = 16, box = None)
+MENTION_2 = api.SpanGroup(
+    spans = [SPAN_2],
+    box_group = None,
+    id = 2,
+    type = None,
+    text = None
+)
+
+# text for this span is "[16] C. Fisch, Centennial of the string galvanometer and the electro- cardiogram"
+BIB_SPAN_1 = api.Span(start = 19, end = 98, box = None)
+BIB_1 = api.SpanGroup(
+    spans = [BIB_SPAN_1],
+    box_group = None,
+    id = 1,
+    type = None,
+    text = None
+)
+
+# text for this span is "4. Wei Zhuo, Qianyi Zhan, Yuan Liu, Zhenping Xie, and Jing Lu. Context attention heterogeneous network embed- ding."
+BIB_SPAN_2 = api.Span(start = 99, end = 213, box = None)
+BIB_2 = api.SpanGroup(
+    spans = [BIB_SPAN_2],
+    box_group = None,
+    id = 2,
+    type = None,
+    text = None
+)
+
+# text for this span is "37 Urban Taco Collective, Tacos with sauce, 2019"
+BIB_SPAN_3 = api.Span(start = 214, end = 261, box = None)
+BIB_3 = api.SpanGroup(
+    spans = [BIB_SPAN_3],
+    box_group = None,
+    id = 3,
+    type = None,
+    text = None
+)
+
+
 @with_timo_container
 class TestInterfaceIntegration(unittest.TestCase):
     def test__predictions(self, container):
-        # single text string representing text contents of pdf
-        symbols = "titlexxxx4xxxx16xxx[16] C. Fisch, Centennial of the string galvanometer and the electro- cardiogram4. Wei Zhuo, Qianyi Zhan, Yuan Liu, Zhenping Xie, and Jing Lu. Context attention heterogeneous network embed- ding.37 Urban Taco Collective, Tacos with sauce, 2019"
-
-        # text for this span is "4"
-        span1 = api.Span(start = 9, end = 10, box = None)
-        mention1 = api.SpanGroup(
-            spans = [span1],
-            box_group = None,
-            id = 1,
-            type = None,
-            text = None
-        )
-
-        # text for this span is "16"
-        span2 = api.Span(start = 14, end = 16, box = None)
-        mention2 = api.SpanGroup(
-            spans = [span2],
-            box_group = None,
-            id = 2,
-            type = None,
-            text = None
-        )
-
-        # text for this span is "[16] C. Fisch, Centennial of the string galvanometer and the electro- cardiogram"
-        bibspan1 = api.Span(start = 19, end = 98, box = None)
-        bib1 = api.SpanGroup(
-            spans = [bibspan1],
-            box_group = None,
-            id = 1,
-            type = None,
-            text = None
-        )
-
-        # text for this span is "4. Wei Zhuo, Qianyi Zhan, Yuan Liu, Zhenping Xie, and Jing Lu. Context attention heterogeneous network embed- ding."
-        bibspan2 = api.Span(start = 99, end = 213, box = None)
-        bib2 = api.SpanGroup(
-            spans = [bibspan2],
-            box_group = None,
-            id = 2,
-            type = None,
-            text = None
-        )
-
-        # text for this span is "37 Urban Taco Collective, Tacos with sauce, 2019"
-        bibspan3 = api.Span(start = 214, end = 261, box = None)
-        bib3 = api.SpanGroup(
-            spans = [bibspan3],
-            box_group = None,
-            id = 3,
-            type = None,
-            text = None
-        )
-
-
         instances = [
-            Instance(symbols = symbols, mentions = [mention1, mention2], bibs = [bib1, bib2, bib3])
+            Instance(symbols = SYMBOLS, mentions = [MENTION_1, MENTION_2], bibs = [BIB_1, BIB_2, BIB_3])
         ]
-
 
         predictions = container.predict_batch(instances)
         self.assertEqual(len(predictions), 1)
 
         predicted_links = predictions[0].linked_mentions
         self.assertEqual(len(predicted_links), 2)
-        self.assertEqual(predicted_links[0], (str(mention1.id), str(bib2.id)))
-        self.assertEqual(predicted_links[1], (str(mention2.id), str(bib1.id)))
+        self.assertEqual(predicted_links[0], (str(MENTION_1.id), str(BIB_2.id)))
+        self.assertEqual(predicted_links[1], (str(MENTION_2.id), str(BIB_1.id)))
 
         predicted_relations = predictions[0].linked_mention_relations
         self.assertEqual(len(predicted_relations), 2)
-        self.assertEqual(predicted_relations[0], api.Relation(from_id=mention1.id, to_id=bib2.id))
-        self.assertEqual(predicted_relations[1], api.Relation(from_id=mention2.id, to_id=bib1.id))
+        self.assertEqual(predicted_relations[0], api.Relation(from_id=MENTION_1.id, to_id=BIB_2.id))
+        self.assertEqual(predicted_relations[1], api.Relation(from_id=MENTION_2.id, to_id=BIB_1.id))
+    def test__predictions_predicts_nothing_when_there_are_no_mentions(self, container):
+        instances = [
+            Instance(symbols = SYMBOLS, mentions = [], bibs = [BIB_1, BIB_2, BIB_3])
+        ]
+
+        predictions = container.predict_batch(instances)
+        self.assertEqual(len(predictions), 1)
+
+        predicted_relations = predictions[0].linked_mention_relations
+        self.assertEqual(len(predicted_relations), 0)
+
+    def test__predictions_predicts_nothing_when_there_are_no_bib_entries(self, container):
+        instances = [
+            Instance(symbols = SYMBOLS, mentions = [MENTION_1, MENTION_2], bibs = [])
+        ]
+
+        predictions = container.predict_batch(instances)
+        self.assertEqual(len(predictions), 1)
+
+        predicted_relations = predictions[0].linked_mention_relations
+        self.assertEqual(len(predicted_relations), 0)
 

--- a/src/mmda/predictors/xgb_predictors/citation_link_predictor.py
+++ b/src/mmda/predictors/xgb_predictors/citation_link_predictor.py
@@ -13,19 +13,22 @@ class CitationLinkPredictor:
         model = xgb.XGBClassifier()
         model.load_model(full_model_path)
         self.model = model
-    
+
     # returns a paired mention id and bib id to represent a link
     def predict(self, doc: Document) -> List[Tuple[str, str]]:
+        if len(doc.bibs) == 0:
+            return []
+
         predicted_links = []
-        
+
         # iterate over mentions
         for mention in doc.mentions:
-            # create all possible links for this mention 
-            possible_links = [] 
+            # create all possible links for this mention
+            possible_links = []
             for bib in doc.bibs:
                 link = CitationLink(mention = mention, bib = bib)
                 possible_links.append(link)
-            
+
             # featurize and find link with highest score
             X_instances = featurize(possible_links)
             y_pred = self.model.predict_proba(X_instances)
@@ -33,7 +36,7 @@ class CitationLinkPredictor:
             match_index = np.argmax(match_scores)
             selected_link = possible_links[match_index]
             predicted_links.append((selected_link.mention.id, selected_link.bib.id))
-        
+
         return predicted_links
-        
+
 


### PR DESCRIPTION
This would previously cause runtime error.
Right thing to do is to detect when we have no bibs, and predict nothing.