### PR TITLE
Bib detector entity like output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.4.0'
+version = '0.4.1'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/src/ai2_internal/bibentry_detection_predictor/integration_test.py
+++ b/src/ai2_internal/bibentry_detection_predictor/integration_test.py
@@ -91,7 +91,8 @@ class TestInterfaceIntegration(unittest.TestCase):
             self.assertEqual(bib_entry.box_group.type, "bib_entry")
 
         for raw_box in predictions[0].raw_bib_entry_boxes:
-            self.assertEqual(raw_box.type, "raw_model_prediction")
+            # raw_bib_entry_boxes are SpanGroups but all data is within the box_group
+            self.assertEqual(raw_box.box_group.type, "raw_model_prediction")
 
         expected_bib_count = 33
         expected_raw_bib_count = 35

--- a/src/ai2_internal/bibentry_detection_predictor/interface.py
+++ b/src/ai2_internal/bibentry_detection_predictor/interface.py
@@ -40,7 +40,7 @@ class Prediction(BaseModel):
     Describes the outcome of inference for one Instance
     """
     bib_entries: List[api.SpanGroup]
-    raw_bib_entry_boxes: List[api.BoxGroup]
+    raw_bib_entry_boxes: List[api.SpanGroup]
 
 
 class PredictorConfig(BaseSettings):
@@ -108,7 +108,7 @@ class Predictor:
                 # filter out span-less SpanGroups
                 bib_entries=[api.SpanGroup.from_mmda(sg) for sg in doc.bib_entries if len(sg.spans) != 0],
                 # retain the original model output
-                raw_bib_entry_boxes=[api.BoxGroup.from_mmda(bg) for bg in original_box_groups]
+                raw_bib_entry_boxes=[api.SpanGroup(spans=[], box_group=api.BoxGroup.from_mmda(bg)) for bg in original_box_groups]
             )
         else:
             prediction = Prediction(


### PR DESCRIPTION
for allenai/scholar#36565
Removes span boxes from bib_entry SpanGroups, and turns raw_bib_entry_boxes from BoxGroups into SpanGroups (with no spans because we just care about saving the boxes here, and calling .annotate with the original box_groups is not necessary).

`tt verify -c src/ai2_internal/config.yaml -v bibentry_detection_predictor` passes

todo:
- [ ] publish new mmda version
- [ ] add it to timo-services config
- [ ] see if SPP is happy with it