### PR TITLE
Speed up merge spans

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.4.2'
+version = '0.4.3'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.4.1'
+version = '0.4.2'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},


### PR DESCRIPTION
This is an optimization PR, and like all optimizations,
it makes the code more confusing, I think. My apologies.

MergeSpans has a quadratic component that bites
us very hard in certain circumstances, like automatically
converting BoxGroups to SpanGroups. It is also a critical
dependency in @comorado 's new tables/figures predictor.

This changeset replaces the nested for-loops in python
with a series of operations against numpy matrices to
the same end effect. Using `tt profile` and a dataset built
from SPP API, I measured a >50% reduction in execution
time.

Note: it is possible to get this down to n*lgn for the special
case of `tokens`, since we have the ncls indices on `doc`.
However, this yielded only marginal benefits for the worst `n`s
we're seeing, and performed slightly worse elsewhere.