### PR TITLE
join symbols in source_text using a space

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.5.1'
+version = '0.5.2'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/src/mmda/featurizers/citation_link_featurizers.py
+++ b/src/mmda/featurizers/citation_link_featurizers.py
@@ -31,7 +31,7 @@ class CitationLink:
         self.bib = bib
 
     def to_text_dict(self) -> Dict[str, str]:
-        return {"source_text": "".join(self.mention.symbols), "target_text": "".join(self.bib.symbols)}
+        return {"source_text": " ".join(self.mention.symbols), "target_text": " ".join(self.bib.symbols)}
 
 def featurize(possible_links: List[CitationLink]) -> pd.DataFrame:
     # create dataframe


### PR DESCRIPTION
When `source_text` is a list of tokens make sure to join them with a space. We weren't doing this which caused the model to see citation text like: `Krawczyketal.2013` which is not that kind of data the model was trained on.

I also join `target_text` with a space, but I havent seen a case where it is a list of length longer than 1.