### PR TITLE
Fix pil issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.7.0'
+version = '0.7.1'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ bibentry_predictor_gpu = [
     'optimum[onnxruntime-gpu]',
 ]
 bibentry_detection_predictor = [
+    'Pillow<10',
     'layoutparser',
     'torch==1.8.0+cu111',
     'torchvision==0.9.0+cu111',


### PR DESCRIPTION
Bib entry predictor is failing its integration tests because
`detectron2` depends on a deprecated `PIL.Image` 
interpolation mode that was removed over the weekend.

This version bounds `Pillow<10` to fix.