### PR TITLE
Kylel/svm word predictor disjoint tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ recipe = CoreRecipe()
 doc: Document = recipe.from_path(pdfpath='...pdf')
 ```
 
+If you'd like, try with this PDF in our test fixtures:
+```python
+doc: Document = recipe.from_path(pdfpath='tests/fixtures/2020.acl-main.447.pdf')
+```
+
 #### 2. Understanding the output: the `Document` class
 
 What is a `Document`? At minimum, it is some text, saved under the `.symbols` field, which is just a `<str>`.  For example:

--- a/tests/test_predictors/test_svm_word_predictor.py
+++ b/tests/test_predictors/test_svm_word_predictor.py
@@ -12,7 +12,9 @@ from typing import List, Optional, Set
 import numpy as np
 
 from mmda.predictors.sklearn_predictors.svm_word_predictor import (
-    SVMClassifier, SVMWordPredictor)
+    SVMClassifier,
+    SVMWordPredictor,
+)
 from mmda.types import Document, Span, SpanGroup
 
 
@@ -302,6 +304,49 @@ class TestSVMWordPredictor(unittest.TestCase):
         )
         self.assertDictEqual(
             word_id_to_text, {0: "I", 1: "am", 2: "the", 3: "wizard-of-oz."}
+        )
+
+    def test_group_adjacent_with_exceptions(self):
+        adjacent = [0, 1, 2, 3]
+
+        # alternating
+        self.assertListEqual(
+            self.predictor._group_adjacent_with_exceptions(
+                adjacent=adjacent, exception_ids={1, 3}
+            ),
+            [[0], [1], [2], [3]],
+        )
+
+        # start
+        self.assertListEqual(
+            self.predictor._group_adjacent_with_exceptions(
+                adjacent=adjacent, exception_ids={0}
+            ),
+            [[0], [1, 2, 3]],
+        )
+
+        # end
+        self.assertListEqual(
+            self.predictor._group_adjacent_with_exceptions(
+                adjacent=adjacent, exception_ids={3}
+            ),
+            [[0, 1, 2], [3]],
+        )
+
+        # none
+        self.assertListEqual(
+            self.predictor._group_adjacent_with_exceptions(
+                adjacent=adjacent, exception_ids=set()
+            ),
+            [[0, 1, 2, 3]],
+        )
+
+        # all
+        self.assertListEqual(
+            self.predictor._group_adjacent_with_exceptions(
+                adjacent=adjacent, exception_ids={0, 1, 2, 3}
+            ),
+            [[0], [1], [2], [3]],
         )
 
     def test_find_hyphen_word_candidates(self):


### PR DESCRIPTION
Had an implementation bug in SVMWordPredictor that was introduced when I was trying to get words to respect token boundaries. Nothing too interesting, basically mis-implemented a for-loop such that it allowed for situations like:

```
token 3 is not punctuation -> word 3
token 4 is punctuation -> word 4
token 5 is not punctuation -> word 3
```

Fix is basically ripping out this for-loop into its own function `_group_adjacent_with_exceptions()` and adding specific tests. 