### PR TITLE
Kylel/fix index error word pred

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.9.0'
+version = '0.9.1'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/src/mmda/predictors/sklearn_predictors/svm_word_predictor.py
+++ b/src/mmda/predictors/sklearn_predictors/svm_word_predictor.py
@@ -9,6 +9,7 @@ classifier to predict whether hyphenated segments should be considered a single 
 
 """
 
+import logging
 import os
 import re
 import tarfile
@@ -30,6 +31,8 @@ from mmda.predictors.sklearn_predictors.base_sklearn_predictor import (
     BaseSklearnPredictor,
 )
 from mmda.types import Document, Metadata, Span, SpanGroup
+
+logger = logging.getLogger(__name__)
 
 
 class IsWordResult:
@@ -117,6 +120,11 @@ class SVMClassifier:
         return classifier
 
     def batch_predict(self, words: List[str], threshold: float) -> List[IsWordResult]:
+        if not all(
+            [not word.startswith("-") and not word.endswith("-") for word in words]
+        ):
+            raise ValueError("Words should not start or end with hyphens.")
+
         all_features, word_id_to_feature_ids = self._get_features(words)
         all_scores = self.estimator.decision_function(all_features)
         results = []
@@ -220,6 +228,9 @@ class SVMWordPredictor(BaseSklearnPredictor):
         return predictor
 
     def predict(self, document: Document) -> List[SpanGroup]:
+        # clean input
+        document = self._make_clean_document(document=document)
+
         # validate input
         self._validate_tokenization(document=document)
 
@@ -296,13 +307,36 @@ class SVMWordPredictor(BaseSklearnPredictor):
         )
         return words
 
+    def _make_clean_document(self, document: Document) -> Document:
+        """Word predictor doesnt work on documents with poor tokenizations,
+        such as when there are empty tokens. This cleans up the document.
+        We keep this pretty minimal, such as ignoring Span Boxes since dont need
+        them for word prediction."""
+        new_tokens = []
+        current_id = 0
+        for token in document.tokens:
+            if token.text.strip() != "":
+                new_token = SpanGroup(
+                    spans=[
+                        Span(start=span.start, end=span.end) for span in token.spans
+                    ],
+                    id=current_id,
+                )
+                new_tokens.append(new_token)
+                current_id += 1
+        new_doc = Document(symbols=document.symbols)
+        new_doc.annotate(tokens=new_tokens)
+        return new_doc
+
     def _recursively_remove_trailing_hyphens(self, word: str) -> str:
         if word.endswith("-"):
             return self._recursively_remove_trailing_hyphens(word=word[:-1])
         else:
             return word
 
-    def _validate_tokenization(self, document: Document):
+    def _validate_tokenization(
+        self, document: Document, allow_empty_tokens: bool = True
+    ):
         """This Word Predictor relies on a specific type of Tokenization
         in which hyphens ('-') must be their own token. This verifies.
 
@@ -319,13 +353,30 @@ class SVMWordPredictor(BaseSklearnPredictor):
                     f"Document contains Token without an `.id` field, which is necessary for this word Predictor's whitespace clustering operation."
                 )
 
-    def _validate_token_word_assignments(self, word_id_to_token_ids):
+        if not allow_empty_tokens:
+            if any([token.text == "" for token in document.tokens]):
+                raise ValueError(
+                    f"Document contains Token with empty text, which is not allowed."
+                )
+
+    def _validate_token_word_assignments(
+        self, word_id_to_token_ids, allow_missed_tokens: bool = True
+    ):
         for word_id, token_ids in word_id_to_token_ids.items():
             start = min(token_ids)
             end = max(token_ids)
             assert (
                 len(token_ids) == end - start + 1
             ), f"word={word_id} comprised of disjoint token_ids={token_ids}"
+
+        if not allow_missed_tokens:
+            all_token_ids = {
+                token_id
+                for token_id in word_id_to_token_ids.values()
+                for token_id in token_ids
+            }
+            if len(all_token_ids) < max(all_token_ids):
+                raise ValueError(f"Not all tokens are assigned to a word.")
 
     def _cluster_tokens_by_whitespace(self, document: Document) -> List[List[int]]:
         """
@@ -340,7 +391,9 @@ class SVMWordPredictor(BaseSklearnPredictor):
         # token -> ws_tokens
         token_id_to_ws_token_id = {}
         for token in document.tokens:
-            token_id_to_ws_token_id[token.id] = token._ws_tokens[0].id
+            overlap_ws_tokens = token._ws_tokens
+            if overlap_ws_tokens:
+                token_id_to_ws_token_id[token.id] = overlap_ws_tokens[0].id
 
         # ws_token -> tokens
         ws_token_id_to_tokens = defaultdict(list)
@@ -475,7 +528,12 @@ class SVMWordPredictor(BaseSklearnPredictor):
         new_word_id = 0
         for token_id in range(1, len(token_id_to_word_id)):
             token = document.tokens[token_id]
-            word_id = token_id_to_word_id[token_id]
+            word_id = token_id_to_word_id.get(token_id)
+            if word_id is None:
+                logger.warning(
+                    f"Token {token_id} has no word ID. Likely PDF Parser produced empty tokens."
+                )
+                continue
             if word_id == current_word_id:
                 tokens_in_word.append(token)
             else:

--- a/src/mmda/predictors/sklearn_predictors/svm_word_predictor.py
+++ b/src/mmda/predictors/sklearn_predictors/svm_word_predictor.py
@@ -546,7 +546,7 @@ class SVMWordPredictor(BaseSklearnPredictor):
             token = document.tokens[token_id]
             word_id = token_id_to_word_id.get(token_id)
             if word_id is None:
-                logger.warning(
+                logger.debug(
                     f"Token {token_id} has no word ID. Likely PDF Parser produced empty tokens."
                 )
                 continue

--- a/src/mmda/predictors/sklearn_predictors/svm_word_predictor.py
+++ b/src/mmda/predictors/sklearn_predictors/svm_word_predictor.py
@@ -120,9 +120,7 @@ class SVMClassifier:
         return classifier
 
     def batch_predict(self, words: List[str], threshold: float) -> List[IsWordResult]:
-        if not all(
-            [not word.startswith("-") and not word.endswith("-") for word in words]
-        ):
+        if any([word.startswith("-") or word.endswith("-") for word in words]):
             raise ValueError("Words should not start or end with hyphens.")
 
         all_features, word_id_to_feature_ids = self._get_features(words)

--- a/src/mmda/predictors/sklearn_predictors/svm_word_predictor.py
+++ b/src/mmda/predictors/sklearn_predictors/svm_word_predictor.py
@@ -332,9 +332,7 @@ class SVMWordPredictor(BaseSklearnPredictor):
         else:
             return word
 
-    def _validate_tokenization(
-        self, document: Document, allow_empty_tokens: bool = True
-    ):
+    def _validate_tokenization(self, document: Document):
         """This Word Predictor relies on a specific type of Tokenization
         in which hyphens ('-') must be their own token. This verifies.
 
@@ -351,8 +349,7 @@ class SVMWordPredictor(BaseSklearnPredictor):
                     f"Document contains Token without an `.id` field, which is necessary for this word Predictor's whitespace clustering operation."
                 )
 
-        if not allow_empty_tokens:
-            if any([token.text == "" for token in document.tokens]):
+            if token.text.strip() == "":
                 raise ValueError(
                     f"Document contains Token with empty text, which is not allowed."
                 )
@@ -524,7 +521,7 @@ class SVMWordPredictor(BaseSklearnPredictor):
         tokens_in_word = [document.tokens[0]]
         current_word_id = 0
         new_word_id = 0
-        for token_id in range(1, len(token_id_to_word_id)):
+        for token_id in range(1, len(document.tokens)):
             token = document.tokens[token_id]
             word_id = token_id_to_word_id.get(token_id)
             if word_id is None:

--- a/tests/test_predictors/test_svm_word_predictor.py
+++ b/tests/test_predictors/test_svm_word_predictor.py
@@ -373,6 +373,30 @@ class TestSVMWordPredictor(unittest.TestCase):
             suffix_word = word_id_to_text[suffix_word_id]
             self.assertTrue("-" in prefix_word + suffix_word)
 
+    # TODO: fix this test
+    def test_with_hyphen_boundaries_not_candidates(self):
+        doc = Document.from_json(
+            doc_dict={
+                "symbols": "COVID- 19",
+                "tokens": [
+                    {"id": 0, "spans": [{"start": 0, "end": 5}]},
+                    {"id": 1, "spans": [{"start": 5, "end": 6}]},
+                    {"id": 2, "spans": [{"start": 7, "end": 9}]},
+                ],
+            }
+        )
+        (
+            token_id_to_word_id,
+            word_id_to_token_ids,
+            word_id_to_text,
+        ) = self.predictor._predict_with_whitespace(document=doc)
+        hyphen_word_candidates = self.predictor._find_hyphen_word_candidates(
+            tokens=doc.tokens,
+            token_id_to_word_id=token_id_to_word_id,
+            word_id_to_token_ids=word_id_to_token_ids,
+            word_id_to_text=word_id_to_text,
+        )
+
     def test_keep_punct_as_words(self):
         doc = Document.from_json(
             doc_dict={

--- a/tests/test_predictors/test_svm_word_predictor.py
+++ b/tests/test_predictors/test_svm_word_predictor.py
@@ -137,7 +137,7 @@ class TestSVMClassifier(unittest.TestCase):
         words = ["-wizard-of-", "wizard-of-"]
         for word in words:
             with self.assertRaises(ValueError):
-                self.classifier._get_features(words=[word])
+                self.classifier.batch_predict(words=[word], threshold=0.0)
 
 
 class TestSVMWordPredictor(unittest.TestCase):

--- a/tests/test_predictors/test_svm_word_predictor.py
+++ b/tests/test_predictors/test_svm_word_predictor.py
@@ -133,6 +133,12 @@ class TestSVMClassifier(unittest.TestCase):
             sum([len(feature) for feature in word_id_to_feature_ids.values()]),
         )
 
+    def test_exception_with_start_or_end_hyphen(self):
+        words = ["-wizard-of-", "wizard-of-"]
+        for word in words:
+            with self.assertRaises(ValueError):
+                self.classifier._get_features(words=[word])
+
 
 class TestSVMWordPredictor(unittest.TestCase):
     @classmethod
@@ -652,4 +658,26 @@ class TestSVMWordPredictor(unittest.TestCase):
         )
         words = self.predictor.predict(document=doc)
         self.assertLess(len(words), len(doc.tokens))
+        doc.annotate(words=words)
+
+    def test_works_with_empty_tokens(self):
+        doc = Document.from_json(
+            doc_dict={
+                "symbols": "I am the wizard-of-oz.",
+                "tokens": [
+                    {"id": 0, "spans": [{"start": 0, "end": 1}]},
+                    {"id": 1, "spans": [{"start": 2, "end": 4}]},
+                    {"id": 2, "spans": [{"start": 5, "end": 8}]},
+                    {"id": 3, "spans": [{"start": 8, "end": 8}]},
+                    {"id": 4, "spans": [{"start": 9, "end": 15}]},
+                    {"id": 5, "spans": [{"start": 15, "end": 16}]},
+                    {"id": 6, "spans": [{"start": 16, "end": 18}]},
+                    {"id": 7, "spans": [{"start": 18, "end": 19}]},
+                    {"id": 8, "spans": [{"start": 19, "end": 19}]},
+                    {"id": 9, "spans": [{"start": 19, "end": 21}]},
+                    {"id": 10, "spans": [{"start": 21, "end": 22}]},
+                ],
+            }
+        )
+        words = self.predictor.predict(document=doc)
         doc.annotate(words=words)


### PR DESCRIPTION
the error here is in the word predictor's `get_features()`. 

at a high-level, the idea of the word predictor is that it loops over each hyphen in a candidate word and predicts whether it should be kept or removed. So a word like `wizard-of-oz` would trigger two predictions, one for each hyphen. The way the model works is it looks at a window surrounding that word to derive features that help with prediction. So for `wizard-of-oz`, the first hyphen's featurization is `wizard, of` and the second hyphen's featurization is `of, oz`.

the problem we're seeing is one due to tokenization. some PDFs result in weird tokenizations where the `token.text.strip() == ""`. I took a look into this, and it's not a bug introduced in our `PDFPlumberTokenizer`, but an upstream issue with just... pdfs in general I guess. When these empty tokens are introduced, it causes situations in which you have words that end with hyphenation. For example, what if there were an empty token between `wizard-of-` and `oz`. 

there are several ways to fix this. one is to fix tokenization, but we'd have to re-drive PDFs, which is too costly at the moment. another is to refactor & retrain the model to know how to properly handle even empty tokenization cases. this is also too costly right now.

so what I've done here is a bit hacky but it's essentially -- add a cleaning step at the beginning of the word predictor's `.predict()` in which we create a new Document that we operate over. as we catch weird issues with tokenization in the future, we can add to this function. all word prediction happens on top of this new document. at the end, we return words as basically start-end spans, so the removal of tokens shouldn't affect how we perform `document.annotate(words=words)` on the original, uncleaned document.