### PR TITLE
bugfix; not sure why but skipping token IDs in some pdfs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.9.4'
+version = '0.9.5'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/src/mmda/predictors/sklearn_predictors/svm_word_predictor.py
+++ b/src/mmda/predictors/sklearn_predictors/svm_word_predictor.py
@@ -402,10 +402,9 @@ class SVMWordPredictor(BaseSklearnPredictor):
             ws_token_id_to_tokens[ws_token_id].append(token_id)
 
         # cluster tokens by whitespace
-        clusters = [
-            sorted(ws_token_id_to_tokens[ws_token_id])
-            for ws_token_id in range(len(ws_token_id_to_tokens))
-        ]
+        clusters = []
+        for ws_token_id, tokens in ws_token_id_to_tokens.items():
+            clusters.append(sorted(tokens))
 
         # cleanup
         document.remove("_ws_tokens")


### PR DESCRIPTION
In PDF `585bcfc650f744efa7942900b742c1b64863350e`

Resolving this issue:
```
Traceback (most recent call last):
  File "/opt/ml/code/server/api.py", line 329, in perform_invocations
    prediction_batch = maybe_predictor.predict_batch(batch)
  File "/usr/local/lib/python3.10/site-packages/ai2_internal/svm_word_predictor/interface.py", line 73, in predict_batch
    return [self.predict_one(instance) for instance in instances]
  File "/usr/local/lib/python3.10/site-packages/ai2_internal/svm_word_predictor/interface.py", line 73, in <listcomp>
    return [self.predict_one(instance) for instance in instances]
  File "/usr/local/lib/python3.10/site-packages/ai2_internal/svm_word_predictor/interface.py", line 56, in predict_one
    words = self._predictor.predict(doc)
  File "/usr/local/lib/python3.10/site-packages/mmda/predictors/sklearn_predictors/svm_word_predictor.py", line 257, in predict
    hyphen_word_candidates = self._find_hyphen_word_candidates(
  File "/usr/local/lib/python3.10/site-packages/mmda/predictors/sklearn_predictors/svm_word_predictor.py", line 504, in _find_hyphen_word_candidates
    prefix_word_id = token_id_to_word_id[hyphen_token_id]
KeyError: 11941
```