### PR TITLE
Bib detector fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.9.6'
+version = '0.9.7'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/src/ai2_internal/bibentry_detection_predictor/interface.py
+++ b/src/ai2_internal/bibentry_detection_predictor/interface.py
@@ -116,8 +116,8 @@ class Predictor:
                 for sg in doc.bib_entries
             ]
             prediction = Prediction(
-                # filter out span-less SpanGroups which occasionally occur
-                bib_entries=[sg for sg in no_span_box_span_groups if len(sg.spans) != 0],
+                # filter out span-less and box-less SpanGroups which occasionally occur
+                bib_entries=[sg for sg in no_span_box_span_groups if (sg.spans and sg.box_group.boxes)],
                 # retain the original model output
                 raw_bib_entry_boxes=[api.SpanGroup(spans=[], box_group=api.BoxGroup.from_mmda(bg), id=bg.id) for bg in original_box_groups]
             )

--- a/src/mmda/predictors/d2_predictors/bibentry_detection_predictor.py
+++ b/src/mmda/predictors/d2_predictors/bibentry_detection_predictor.py
@@ -43,17 +43,19 @@ def tighten_boxes(bib_box_group, page_tokens, page_width, page_height):
             abs_box.l + abs_box.w,
             abs_box.t + abs_box.h
         )
-        new_rect = union_blocks(page_tokens_as_layout.filter_by(rect, center=True))
-        new_boxes.append(
-            Box(l=new_rect.x_1,
-                t=new_rect.y_1,
-                w=new_rect.width,
-                h=new_rect.height,
-                page=box.page).get_relative(
-                page_width=page_width,
-                page_height=page_height,
+        intersecting_page_tokens = page_tokens_as_layout.filter_by(rect, center=True)
+        if intersecting_page_tokens:
+            new_rect = union_blocks(intersecting_page_tokens)
+            new_boxes.append(
+                Box(l=new_rect.x_1,
+                    t=new_rect.y_1,
+                    w=new_rect.width,
+                    h=new_rect.height,
+                    page=box.page).get_relative(
+                    page_width=page_width,
+                    page_height=page_height,
+                )
             )
-        )
     new_box_group = BoxGroup(
         boxes=new_boxes,
         id=bib_box_group.id


### PR DESCRIPTION
Fixes bibentry detector issue with orphaned boxes

RE: https://github.com/allenai/scholar/issues/35308

    Sometimes the detector predicts boxes that don't intersect
    any tokens on the page. In these cases we should discard
    the box, as it doesn't map to text and causes a runtime error
    otherwise.