### PR TITLE
grobid augmenter parser: don't fail with bad coords

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.9.8'
+version = '0.9.9'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/src/mmda/parsers/grobid_augment_existing_document_parser.py
+++ b/src/mmda/parsers/grobid_augment_existing_document_parser.py
@@ -6,6 +6,7 @@
 from grobid_client.grobid_client import GrobidClient
 from typing import List, Optional
 
+import logging
 import os
 import xml.etree.ElementTree as et
 
@@ -104,13 +105,17 @@ class GrobidAugmentExistingDocumentParser(Parser):
         coords_list = coords_attribute.split(";")
         boxes = []
         for coords in coords_list:
-            pg, x, y, w, h = coords.split(",")
-            proper_page = int(pg) - 1
-            boxes.append(
-                Box(
-                    l=float(x), t=float(y), w=float(w), h=float(h), page=proper_page
-                ).get_relative(*self.page_sizes[proper_page])
-            )
+            try:
+                pg, x, y, w, h = coords.split(",")
+                proper_page = int(pg) - 1
+                boxes.append(
+                    Box(
+                        l=float(x), t=float(y), w=float(w), h=float(h), page=proper_page
+                    ).get_relative(*self.page_sizes[proper_page])
+                )
+            except ValueError:
+                logging.warning(f"Could not parse coords: '{coords}'")
+                pass
         return boxes
 
     def _cache_page_sizes(self, root: et.Element):


### PR DESCRIPTION
makes converting empty `coords` string failproof (fix for error type 1 that was showing up with some bib refs in https://github.com/allenai/scholar/issues/37426)

todo:
- [ ] publish 0.9.9