### PR TITLE
Fix for sg overlap error in box_groups_to_span_groups when center=true

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.9.12'
+version = '0.9.13'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/src/mmda/utils/tools.py
+++ b/src/mmda/utils/tools.py
@@ -121,8 +121,7 @@ def box_groups_to_span_groups(
         derived_spans = merge_spans.merge_neighbor_spans_by_symbol_distance()
 
         # tokens overlapping with derived spans:
-        doc.annotate(derived_span_group=[SpanGroup(spans=derived_spans)])
-        sg_tokens = doc.derived_span_group[0].tokens
+        sg_tokens = doc.find_overlapping(SpanGroup(spans=derived_spans), "tokens")
 
         # remove any additional tokens added to the spangroup via MergeSpans from the list of available page tokens
         # (this can happen if the MergeSpans algorithm merges tokens that are not adjacent, e.g. if `center` is True and
@@ -133,7 +132,6 @@ def box_groups_to_span_groups(
                     all_page_tokens[sg_token.box_group.boxes[0].page].remove(sg_token)
                 else:
                     all_page_tokens[sg_token.spans[0].box.page].remove(sg_token)
-        doc.remove("derived_span_group")
 
         derived_span_groups.append(
             SpanGroup(

--- a/src/mmda/utils/tools.py
+++ b/src/mmda/utils/tools.py
@@ -15,7 +15,7 @@ from mmda.types.span import Span
 
 def allocate_overlapping_tokens_for_box(
         tokens: List[SpanGroup], box, token_box_in_box_group: bool = False, x: float = 0.0, y: float = 0.0, center: bool = False
-) -> Tuple[List[Span], List[Span]]:
+) -> Tuple[List[SpanGroup], List[SpanGroup]]:
     """Finds overlap of tokens for given box
     Args
         `tokens` (List[SpanGroup])
@@ -102,7 +102,6 @@ def box_groups_to_span_groups(
                 center=center
             )
             all_page_tokens[box.page] = remaining_tokens
-
             all_tokens_overlapping_box_group.extend(tokens_in_box)
 
         merge_spans = (
@@ -119,10 +118,26 @@ def box_groups_to_span_groups(
                 index_distance=1,
             )
         )
+        derived_spans = merge_spans.merge_neighbor_spans_by_symbol_distance()
+
+        # tokens overlapping with derived spans:
+        doc.annotate(derived_span_group=[SpanGroup(spans=derived_spans)])
+        sg_tokens = doc.derived_span_group[0].tokens
+
+        # remove any additional tokens added to the spangroup via MergeSpans from the list of available page tokens
+        # (this can happen if the MergeSpans algorithm merges tokens that are not adjacent, e.g. if `center` is True and
+        # a token is not found to be overlapping with the box, but MergeSpans decides it is close enough to be merged)
+        for sg_token in sg_tokens:
+            if sg_token not in all_tokens_overlapping_box_group:
+                if token_box_in_box_group:
+                    all_page_tokens[sg_token.box_group.boxes[0].page].remove(sg_token)
+                else:
+                    all_page_tokens[sg_token.spans[0].box.page].remove(sg_token)
+        doc.remove("derived_span_group")
 
         derived_span_groups.append(
             SpanGroup(
-                spans=merge_spans.merge_neighbor_spans_by_symbol_distance(),
+                spans=derived_spans,
                 box_group=box_group,
                 # id = box_id,
             )


### PR DESCRIPTION
Solution for https://github.com/allenai/scholar/issues/38452
The problem was in running `box_groups_to_span_groups` with `center=True`. We want to keep `center=True` because it allows us to get good texts in most cases when converting from Grobid box groups to MMDA spangroups. However in some cases it was causing a problem.
The overlapping spangroups error seen from spp-grobid was always a single character span found in 2 different spangroups. This was due to single character tokens that were sometimes not found to be overlapping with the box when running `allocate_overlapping_tokens_for_box`, but then got swallowed up with MergeSpans, and we weren't accounting for this. We now update the dictionary containing the remaining allocatable tokens _after_ `merge_neighbor_spans_by_symbol_distance` is used to derive a SpanGroup with all the tokens used (instead of just the tokens whose centers overlapped with the original box)