### PR TITLE
bugfix for box_groups_to_span_groups when center=True

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.9.13'
+version = '0.9.14'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/src/mmda/utils/tools.py
+++ b/src/mmda/utils/tools.py
@@ -128,9 +128,9 @@ def box_groups_to_span_groups(
         # a token is not found to be overlapping with the box, but MergeSpans decides it is close enough to be merged)
         for sg_token in sg_tokens:
             if sg_token not in all_tokens_overlapping_box_group:
-                if token_box_in_box_group:
+                if token_box_in_box_group and sg_token in all_page_tokens[sg_token.box_group.boxes[0].page]:
                     all_page_tokens[sg_token.box_group.boxes[0].page].remove(sg_token)
-                else:
+                elif not token_box_in_box_group and sg_token in all_page_tokens[sg_token.spans[0].box.page]:
                     all_page_tokens[sg_token.spans[0].box.page].remove(sg_token)
 
         derived_span_groups.append(


### PR DESCRIPTION
this is a bug fix for an error made in https://github.com/allenai/mmda/pull/276
It's possible to find tokens from the original Document overlapping with the MergedSpan SpanGroup that are already allocated to a different SpanGroup, so we need to check first if it's in the list of available tokens before attempting to remove it. 

todo:
- [ ] publish new version