### PR TITLE
Caps max allowed version of transformers for vila.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.9.14'
+version = '0.9.15'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ hf_predictors = [
 ]
 vila_predictors = [
     'vila>=0.5,<0.6',
-    'transformers',
+    'transformers<4.34.0',
 ]
 mention_predictor = [
     'transformers[torch]',


### PR DESCRIPTION
v4.34.0 release did a complete refactor of the tokenizer module, see:

https://github.com/huggingface/transformers/pull/23909

Something about the difference is causing vila to
produce literally billions of lines of log warning messages to Datadog in prod. 
I don't know if these warnings are meaningful, but they are expensive.

Example logs:
https://app.datadoghq.com/logs?query=service%3Avila-v0%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=paused&stream_sort=desc&viz=stream&from_ts=1697556761689&to_ts=1697557153857&live=false