### PR TITLE
Refactor grobid sections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.9.15'
+version = '0.9.16'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/src/mmda/parsers/grobid_augment_existing_document_parser.py
+++ b/src/mmda/parsers/grobid_augment_existing_document_parser.py
@@ -115,8 +115,9 @@ class GrobidAugmentExistingDocumentParser(Parser):
         unallocated_section_tokens_dict: Dict[int, SpanGroup] = dict()
 
         for heading_box_group, paragraphs in section_headings_and_sentence_box_groups_in_paragraphs:
+            section_spans = []
             if heading_box_group:
-                heading_span_group, unallocated_section_tokens_dict = (
+                heading_span_group_in_list, unallocated_section_tokens_dict = (
                     box_groups_to_span_groups(
                         [heading_box_group],
                         doc,
@@ -124,7 +125,9 @@ class GrobidAugmentExistingDocumentParser(Parser):
                         unallocated_tokens_dict=unallocated_section_tokens_dict
                     )
                 )
-                heading_span_groups.extend(heading_span_group)
+                heading_span_group = heading_span_group_in_list[0]
+                heading_span_groups.append(heading_span_group)
+                section_spans.extend(heading_span_group.spans)
             this_section_paragraph_span_groups = []
             for sentence_box_groups in paragraphs:
                 this_paragraph_sentence_span_groups, unallocated_section_tokens_dict = box_groups_to_span_groups(
@@ -137,11 +140,12 @@ class GrobidAugmentExistingDocumentParser(Parser):
                 paragraph_spans = []
                 for sg in this_paragraph_sentence_span_groups:
                     paragraph_spans.extend(sg.spans)
+                # TODO add boxes to paragraph spangroups
                 this_section_paragraph_span_groups.append(SpanGroup(spans=paragraph_spans))
             paragraph_span_groups.extend(this_section_paragraph_span_groups)
-            section_spans = []
             for sg in this_section_paragraph_span_groups:
                 section_spans.extend(sg.spans)
+            # TODO add boxes to section spangroups
             section_span_groups.append(SpanGroup(spans=section_spans))
             
         doc.annotate(headings=heading_span_groups)

--- a/src/mmda/parsers/grobid_augment_existing_document_parser.py
+++ b/src/mmda/parsers/grobid_augment_existing_document_parser.py
@@ -137,7 +137,8 @@ class GrobidAugmentExistingDocumentParser(Parser):
                     pad_x=True,
                     unallocated_tokens_dict=unallocated_section_tokens_dict
                     ) 
-                sentence_span_groups.extend(this_paragraph_sentence_span_groups)
+                if all([sg.spans for sg in this_paragraph_sentence_span_groups]):
+                    sentence_span_groups.extend(this_paragraph_sentence_span_groups)
                 paragraph_spans = []
                 for sg in this_paragraph_sentence_span_groups:
                     paragraph_spans.extend(sg.spans)

--- a/src/mmda/parsers/grobid_augment_existing_document_parser.py
+++ b/src/mmda/parsers/grobid_augment_existing_document_parser.py
@@ -147,7 +147,13 @@ class GrobidAugmentExistingDocumentParser(Parser):
                 section_spans.extend(sg.spans)
             # TODO add boxes to section spangroups
             section_span_groups.append(SpanGroup(spans=section_spans))
-            
+
+        # ensure unique IDs within annotations
+        all_section_span_groups = [heading_span_groups, sentence_span_groups, paragraph_span_groups, section_span_groups]
+        for span_groups in all_section_span_groups:
+            for i, span_group in enumerate(span_groups):
+                span_group.id = i
+
         doc.annotate(headings=heading_span_groups)
         doc.annotate(sentences=sentence_span_groups)
         doc.annotate(paragraphs=paragraph_span_groups)

--- a/src/mmda/parsers/grobid_augment_existing_document_parser.py
+++ b/src/mmda/parsers/grobid_augment_existing_document_parser.py
@@ -4,7 +4,7 @@
 
 """
 from grobid_client.grobid_client import GrobidClient
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Dict
 
 import logging
 import os
@@ -112,12 +112,27 @@ class GrobidAugmentExistingDocumentParser(Parser):
         section_span_groups = []
         sentence_span_groups = []
 
+        unallocated_section_tokens_dict: Dict[int, SpanGroup] = dict()
+
         for heading_box_group, paragraphs in section_headings_and_sentence_box_groups_in_paragraphs:
             if heading_box_group:
-                heading_span_groups.extend(box_groups_to_span_groups([heading_box_group], doc, center=True))
+                heading_span_group, unallocated_section_tokens_dict = (
+                    box_groups_to_span_groups(
+                        [heading_box_group],
+                        doc,
+                        center=True,
+                        unallocated_tokens_dict=unallocated_section_tokens_dict
+                    )
+                )
+                heading_span_groups.extend(heading_span_group)
             this_section_paragraph_span_groups = []
             for sentence_box_groups in paragraphs:
-                this_paragraph_sentence_span_groups = box_groups_to_span_groups(sentence_box_groups, doc, center=True) 
+                this_paragraph_sentence_span_groups, unallocated_section_tokens_dict = box_groups_to_span_groups(
+                    sentence_box_groups, 
+                    doc, 
+                    center=True,
+                    unallocated_tokens_dict=unallocated_section_tokens_dict
+                    ) 
                 sentence_span_groups.extend(this_paragraph_sentence_span_groups)
                 paragraph_spans = []
                 for sg in this_paragraph_sentence_span_groups:

--- a/src/mmda/parsers/grobid_augment_existing_document_parser.py
+++ b/src/mmda/parsers/grobid_augment_existing_document_parser.py
@@ -209,7 +209,11 @@ class GrobidAugmentExistingDocumentParser(Parser):
             elements = item_list_root.findall(f".//tei:{item_tag}", NS)
 
         for e in elements:
-            coords_string = e.attrib["coords"]
+            try:
+                coords_string = e.attrib["coords"]
+            except KeyError:
+                logging.warning(f"Element with '{item_tag}' tag missing 'coords' attribute")
+                continue
             boxes = self._xml_coords_to_boxes(coords_string)
 
             grobid_id = e.attrib[ID_ATTR_KEY] if ID_ATTR_KEY in e.keys() else None
@@ -241,7 +245,11 @@ class GrobidAugmentExistingDocumentParser(Parser):
         box_group = None
         heading_element = section_div.find(f".//tei:head", NS)
         if heading_element is not None:  # elements evaluate as False if no children
-            coords_string = heading_element.attrib["coords"]
+            try:
+                coords_string = heading_element.attrib["coords"]
+            except KeyError:
+                logging.warning(f"Heading element missing 'coords' attribute")
+                return None
             boxes = self._xml_coords_to_boxes(coords_string)
             number = heading_element.attrib["n"] if "n" in heading_element.keys() else None
             section_title = heading_element.text
@@ -265,7 +273,12 @@ class GrobidAugmentExistingDocumentParser(Parser):
             for p in div.findall(f"./tei:p", NS):
                 sentence_box_groups: List[BoxGroup] = []
                 for s in p.findall(f"./tei:s", NS):
-                    sentence_boxes = self._xml_coords_to_boxes(s.attrib["coords"])
+                    try:
+                        coords_string = s.attrib["coords"]
+                    except KeyError:
+                        logging.warning(f"Sentence element missing 'coords' attribute")
+                        continue
+                    sentence_boxes = self._xml_coords_to_boxes(coords_string)
                     sentence_box_groups.append(BoxGroup(boxes=sentence_boxes))
                 paragraphs.append(sentence_box_groups)
                 

--- a/src/mmda/parsers/grobid_augment_existing_document_parser.py
+++ b/src/mmda/parsers/grobid_augment_existing_document_parser.py
@@ -4,7 +4,7 @@
 
 """
 from grobid_client.grobid_client import GrobidClient
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import logging
 import os
@@ -104,32 +104,40 @@ class GrobidAugmentExistingDocumentParser(Parser):
         # sentences within the body text, also tagged by paragraphs.
         # We use these to annotate the document in order to provide a hierarchical structure:
         # e.g. doc.sections.header, doc.sections[0].paragraphs[0].sentences[0]
-        section_box_groups, heading_box_groups, paragraph_box_groups, sentence_box_groups = \
-            self._get_structured_body_text_box_groups(xml_root)
-        doc.annotate(
-            sections=box_groups_to_span_groups(
-                section_box_groups, doc, center=True
-            )
-        )
-        doc.annotate(
-            headings=box_groups_to_span_groups(
-                heading_box_groups, doc, center=True
-            )
-        )
-        doc.annotate(
-            paragraphs=box_groups_to_span_groups(
-                paragraph_box_groups, doc, center=True
-            )
-        )
-        doc.annotate(
-            sentences=box_groups_to_span_groups(
-                sentence_box_groups, doc, center=True
-            )
-        )
+        section_headings_and_sentence_box_groups_in_paragraphs = \
+            self._get_structured_sentence_box_groups(xml_root)
+        
+        heading_span_groups = []
+        paragraph_span_groups = []
+        section_span_groups = []
+        sentence_span_groups = []
+
+        for heading_box_group, paragraphs in section_headings_and_sentence_box_groups_in_paragraphs:
+            if heading_box_group:
+                heading_span_groups.extend(box_groups_to_span_groups([heading_box_group], doc, center=True))
+            this_section_paragraph_span_groups = []
+            for sentence_box_groups in paragraphs:
+                this_paragraph_sentence_span_groups = box_groups_to_span_groups(sentence_box_groups, doc, center=True) 
+                sentence_span_groups.extend(this_paragraph_sentence_span_groups)
+                paragraph_spans = []
+                for sg in this_paragraph_sentence_span_groups:
+                    paragraph_spans.extend(sg.spans)
+                this_section_paragraph_span_groups.append(SpanGroup(spans=paragraph_spans))
+            paragraph_span_groups.extend(this_section_paragraph_span_groups)
+            section_spans = []
+            for sg in this_section_paragraph_span_groups:
+                section_spans.extend(sg.spans)
+            section_span_groups.append(SpanGroup(spans=section_spans))
+            
+        doc.annotate(headings=heading_span_groups)
+        doc.annotate(sentences=sentence_span_groups)
+        doc.annotate(paragraphs=paragraph_span_groups)
+        doc.annotate(sections=section_span_groups)
+
 
         return doc
 
-    def _xml_coords_to_boxes(self, coords_attribute: str):
+    def _xml_coords_to_boxes(self, coords_attribute: str) -> List[Box]:
         coords_list = coords_attribute.split(";")
         boxes = []
         for coords in coords_list:
@@ -218,34 +226,24 @@ class GrobidAugmentExistingDocumentParser(Parser):
             )
         return box_group
 
-    def _get_structured_body_text_box_groups(
+    def _get_structured_sentence_box_groups(
             self,
             root: et.Element
-    ) -> (List[BoxGroup], List[BoxGroup], List[BoxGroup], List[BoxGroup]):
+    ) -> List[Tuple[Optional[BoxGroup], List[List[BoxGroup]]]]:
         section_list_root = root.find(f".//tei:body", NS)
-
-        body_sections: List[BoxGroup] = []
-        body_headings: List[BoxGroup] = []
-        body_paragraphs: List[BoxGroup] = []
-        body_sentences: List[BoxGroup] = []
-
         section_divs = section_list_root.findall(f"./tei:div", NS)
+
+        section_structures = []
         for div in section_divs:
-            section_boxes: List[Box] = []
             heading_box_group = self._get_heading_box_group(div)
-            if heading_box_group:
-                body_headings.append(heading_box_group)
-                section_boxes.extend(heading_box_group.boxes)
+            paragraphs: List[List[BoxGroup]] = []
             for p in div.findall(f"./tei:p", NS):
-                paragraph_boxes: List[Box] = []
-                paragraph_sentences: List[BoxGroup] = []
+                sentence_box_groups: List[BoxGroup] = []
                 for s in p.findall(f"./tei:s", NS):
                     sentence_boxes = self._xml_coords_to_boxes(s.attrib["coords"])
-                    paragraph_sentences.append(BoxGroup(boxes=sentence_boxes))
-                    paragraph_boxes.extend(sentence_boxes)
-                body_paragraphs.append(BoxGroup(boxes=paragraph_boxes))
-                section_boxes.extend(paragraph_boxes)
-                body_sentences.extend(paragraph_sentences)
-            body_sections.append(BoxGroup(boxes=section_boxes))
+                    sentence_box_groups.append(BoxGroup(boxes=sentence_boxes))
+                paragraphs.append(sentence_box_groups)
+                
+            section_structures.append([heading_box_group, paragraphs])
 
-        return body_sections, body_headings, body_paragraphs, body_sentences
+        return section_structures

--- a/src/mmda/parsers/grobid_augment_existing_document_parser.py
+++ b/src/mmda/parsers/grobid_augment_existing_document_parser.py
@@ -117,12 +117,13 @@ class GrobidAugmentExistingDocumentParser(Parser):
         for heading_box_group, paragraphs in section_headings_and_sentence_box_groups_in_paragraphs:
             section_spans = []
             if heading_box_group:
-                heading_span_group_in_list, unallocated_section_tokens_dict = (
+                heading_span_group_in_list = (
                     box_groups_to_span_groups(
                         [heading_box_group],
                         doc,
                         center=True,
-                        unallocated_tokens_dict=unallocated_section_tokens_dict
+                        unallocated_tokens_dict=unallocated_section_tokens_dict,
+                        fix_overlaps=True,
                     )
                 )
                 heading_span_group = heading_span_group_in_list[0]
@@ -130,12 +131,13 @@ class GrobidAugmentExistingDocumentParser(Parser):
                 section_spans.extend(heading_span_group.spans)
             this_section_paragraph_span_groups = []
             for sentence_box_groups in paragraphs:
-                this_paragraph_sentence_span_groups, unallocated_section_tokens_dict = box_groups_to_span_groups(
+                this_paragraph_sentence_span_groups = box_groups_to_span_groups(
                     sentence_box_groups, 
                     doc, 
                     center=True,
                     pad_x=True,
-                    unallocated_tokens_dict=unallocated_section_tokens_dict
+                    unallocated_tokens_dict=unallocated_section_tokens_dict,
+                    fix_overlaps=True,
                     ) 
                 if all([sg.spans for sg in this_paragraph_sentence_span_groups]):
                     sentence_span_groups.extend(this_paragraph_sentence_span_groups)

--- a/src/mmda/parsers/grobid_augment_existing_document_parser.py
+++ b/src/mmda/parsers/grobid_augment_existing_document_parser.py
@@ -12,7 +12,7 @@ import xml.etree.ElementTree as et
 
 from mmda.parsers.parser import Parser
 from mmda.types import Metadata
-from mmda.types.annotation import BoxGroup, Box, SpanGroup
+from mmda.types.annotation import BoxGroup, Box, SpanGroup, Span
 from mmda.types.document import Document
 from mmda.types.names import PagesField, RowsField, TokensField
 from mmda.utils.tools import box_groups_to_span_groups
@@ -134,6 +134,7 @@ class GrobidAugmentExistingDocumentParser(Parser):
                     sentence_box_groups, 
                     doc, 
                     center=True,
+                    pad_x=True,
                     unallocated_tokens_dict=unallocated_section_tokens_dict
                     ) 
                 sentence_span_groups.extend(this_paragraph_sentence_span_groups)

--- a/src/mmda/utils/tools.py
+++ b/src/mmda/utils/tools.py
@@ -65,7 +65,7 @@ def box_groups_to_span_groups(
     """
     assert all([isinstance(group, BoxGroup) for group in box_groups])
 
-    unallocated_tokens = unallocated_tokens_dict if unallocated_tokens_dict else dict()
+    unallocated_tokens = unallocated_tokens_dict if unallocated_tokens_dict is not None else dict()
     avg_token_widths = dict()
     derived_span_groups = []
     token_box_in_box_group = None

--- a/src/mmda/utils/tools.py
+++ b/src/mmda/utils/tools.py
@@ -136,7 +136,7 @@ def box_groups_to_span_groups(
         # tokens overlapping with derived spans:
         sg_tokens = doc.find_overlapping(SpanGroup(spans=derived_spans), "tokens")
 
-        def update_derived_spans(t_span):
+        def omit_span_from_derived_spans(t_span):
             # if the sg_token is in the derived_span, cut it out by updating derived_spans.
             # this can happen because merge_spans finds min number of spans and can merge spans that 
             # cover tokens that were already allocated. We update this to avoid spangroup overlap errors.
@@ -168,13 +168,13 @@ def box_groups_to_span_groups(
                     # is that the token has already been allocated by a different box_group, so, we need to remove it from our
                     # derived spans to avoid 'SpanGroup overlap' error.
                     else:
-                        update_derived_spans(sg_token.spans[0])
+                        omit_span_from_derived_spans(sg_token.spans[0])
                 else:
                     if sg_token in unallocated_tokens[sg_token.spans[0].box.page]:
                         unallocated_tokens[sg_token.spans[0].box.page].remove(sg_token)
                     # same scenario as above.
                     else:
-                        update_derived_spans(sg_token.spans[0]) 
+                        omit_span_from_derived_spans(sg_token.spans[0]) 
 
 
         # if derived_span_group encompasses any tokens that were NOT in unallocated_tokens, we need to REMOVE 

--- a/src/mmda/utils/tools.py
+++ b/src/mmda/utils/tools.py
@@ -4,7 +4,7 @@ import logging
 from collections import defaultdict
 from itertools import groupby
 import itertools
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Optional, Union
 
 import numpy as np
 
@@ -41,20 +41,33 @@ def allocate_overlapping_tokens_for_box(
 
 
 def box_groups_to_span_groups(
-        box_groups: List[BoxGroup], doc: Document, pad_x: bool = False, center: bool = False
-) -> List[SpanGroup]:
-    """Generate SpanGroups from BoxGroups.
+        box_groups: List[BoxGroup],
+        doc,
+        pad_x: bool = False,
+        center: bool = False,
+        unallocated_tokens_dict:  Optional[Dict[int, SpanGroup]] = None
+) -> Union[List[SpanGroup], Tuple[List[SpanGroup], Dict[int, SpanGroup]]]:
+    """Generate SpanGroups from BoxGroups given they can only generate spans of tokens not already allocated
     Args
         `box_groups` (List[BoxGroup])
         `doc` (Document) base document annotated with pages, tokens, rows to
         `center` (bool) if True, considers tokens to be overlapping with boxes only if their centers overlap
+        `unallocated_tokens` (Optional[Dict]) of token spangroups keyed by page. If provided, will use as starting
+        point for determining if token is already allocated. Assumes the tokens within are of the same type as the `doc`
+        (i.e., tokens from both doc and the dict both have their box data in either Span.box or SpanGroup.boxgroup)
     Returns
-        List[SpanGroup] with each SpanGroup.spans corresponding to spans (sans boxes) of allocated tokens per box_group,
+        Union (either) of:
+         -List[SpanGroup] with each SpanGroup.spans corresponding to spans (sans boxes) of allocated tokens per box_group,
         and each SpanGroup.box_group containing original box_groups
+        or Tuple of:
+         -List[SpanGroup] as described above, and
+         -Dictionary of unallocated tokens keyed by page
     """
     assert all([isinstance(group, BoxGroup) for group in box_groups])
 
-    all_page_tokens = dict()
+    return_unallocated_tokens = unallocated_tokens_dict is not None
+
+    unallocated_tokens = unallocated_tokens_dict if return_unallocated_tokens else dict()
     avg_token_widths = dict()
     derived_span_groups = []
     token_box_in_box_group = None
@@ -66,8 +79,8 @@ def box_groups_to_span_groups(
         for box in box_group.boxes:
 
             # Caching the page tokens to avoid duplicated search
-            if box.page not in all_page_tokens:
-                cur_page_tokens = all_page_tokens[box.page] = doc.pages[
+            if box.page not in unallocated_tokens:
+                cur_page_tokens = unallocated_tokens[box.page] = doc.pages[
                     box.page
                 ].tokens
                 if token_box_in_box_group is None:
@@ -89,7 +102,7 @@ def box_groups_to_span_groups(
                             avg_token_widths[box.page] = np.average([t.spans[0].box.w for t in cur_page_tokens])
 
             else:
-                cur_page_tokens = all_page_tokens[box.page]
+                cur_page_tokens = unallocated_tokens[box.page]
 
             # Find all the tokens within the box
             tokens_in_box, remaining_tokens = allocate_overlapping_tokens_for_box(
@@ -101,7 +114,7 @@ def box_groups_to_span_groups(
                 y=0.0,
                 center=center
             )
-            all_page_tokens[box.page] = remaining_tokens
+            unallocated_tokens[box.page] = remaining_tokens
             all_tokens_overlapping_box_group.extend(tokens_in_box)
 
         merge_spans = (
@@ -128,10 +141,12 @@ def box_groups_to_span_groups(
         # a token is not found to be overlapping with the box, but MergeSpans decides it is close enough to be merged)
         for sg_token in sg_tokens:
             if sg_token not in all_tokens_overlapping_box_group:
-                if token_box_in_box_group and sg_token in all_page_tokens[sg_token.box_group.boxes[0].page]:
-                    all_page_tokens[sg_token.box_group.boxes[0].page].remove(sg_token)
-                elif not token_box_in_box_group and sg_token in all_page_tokens[sg_token.spans[0].box.page]:
-                    all_page_tokens[sg_token.spans[0].box.page].remove(sg_token)
+                if token_box_in_box_group and sg_token in unallocated_tokens[sg_token.box_group.boxes[0].page]:
+                    unallocated_tokens[sg_token.box_group.boxes[0].page].remove(sg_token)
+                elif not token_box_in_box_group and sg_token in unallocated_tokens[sg_token.spans[0].box.page]:
+                    unallocated_tokens[sg_token.spans[0].box.page].remove(sg_token)
+
+
 
         derived_span_groups.append(
             SpanGroup(
@@ -148,20 +163,15 @@ def box_groups_to_span_groups(
                         "future Spans wont contain box). Ensure Document is annotated with tokens "
                         "having box stored in SpanGroup box_group.boxes")
 
-    del all_page_tokens
-
     derived_span_groups = sorted(
         derived_span_groups, key=lambda span_group: span_group.start
     )
     # ensure they are ordered based on span indices
-
     for box_id, span_group in enumerate(derived_span_groups):
         span_group.id = box_id
 
-    # return self._annotate_span_group(
-    #     span_groups=derived_span_groups, field_name=field_name
-    # )
-    return derived_span_groups
+    return (derived_span_groups, unallocated_tokens) if return_unallocated_tokens else derived_span_groups
+
 
 class MergeSpans:
     """

--- a/src/mmda/utils/tools.py
+++ b/src/mmda/utils/tools.py
@@ -174,9 +174,6 @@ def box_groups_to_span_groups(
                     else:
                         omit_span_from_derived_spans(sg_token.spans[0]) 
 
-
-        # if derived_span_group encompasses any tokens that were NOT in unallocated_tokens, we need to REMOVE 
-        # that spangroup here... wait maybe not.
         derived_span_groups.append(
             SpanGroup(
                 spans=derived_spans,

--- a/src/mmda/utils/tools.py
+++ b/src/mmda/utils/tools.py
@@ -46,7 +46,7 @@ def box_groups_to_span_groups(
         pad_x: bool = False,
         center: bool = False,
         unallocated_tokens_dict:  Optional[Dict[int, SpanGroup]] = None
-) -> Union[List[SpanGroup], Tuple[List[SpanGroup], Dict[int, SpanGroup]]]:
+) -> List[SpanGroup]:
     """Generate SpanGroups from BoxGroups given they can only generate spans of tokens not already allocated
     Args
         `box_groups` (List[BoxGroup])
@@ -65,9 +65,7 @@ def box_groups_to_span_groups(
     """
     assert all([isinstance(group, BoxGroup) for group in box_groups])
 
-    return_unallocated_tokens = unallocated_tokens_dict is not None
-
-    unallocated_tokens = unallocated_tokens_dict if return_unallocated_tokens else dict()
+    unallocated_tokens = unallocated_tokens_dict if unallocated_tokens_dict else dict()
     avg_token_widths = dict()
     derived_span_groups = []
     token_box_in_box_group = None
@@ -201,7 +199,7 @@ def box_groups_to_span_groups(
     for box_id, span_group in enumerate(derived_span_groups):
         span_group.id = box_id
 
-    return (derived_span_groups, unallocated_tokens) if return_unallocated_tokens else derived_span_groups
+    return derived_span_groups
 
 
 class MergeSpans:


### PR DESCRIPTION
Solution to https://github.com/allenai/scholar/issues/38452 

Refactored the way Grobid sections/paragraphs/sentences are annotated onto the doc to reduce SpanGroup overlap errors

This involved refactoring the "sections" section of the code to only generate spangroups from sentences and headings (since those are the boxgroups Grobid provides) and using tuples of [optional[heading], [list of paragraphs[list of sentences]]] to make the hierarchical section/paragraph spangroups instead of trying to make huge box lists for each piece as originally written. This made it easier to pinpoint the source of SpanGroup overlap errors.

A necessary update was to make _box_groups_to_span_groups keep track of which tokens were already allocated in previous sentences, since we loop through by Grobid paragraph tags, and we were sometimes overlapping between paragraphs.

> example of previously failing (now passing) pdf
> grobid xml has a ".":
> 
> ![image](https://user-images.githubusercontent.com/7800734/278456719-27a8306b-40d6-4579-825f-43f15d65a054.png)
> 
> the actual PDF does not:  
> 
> ![image](https://user-images.githubusercontent.com/7800734/278456482-0d14d8df-1bde-4753-a5ee-09cacde62a44.png)
> 
> we end up with overlapping spangroups 
> A:  
> 
> ![image](https://user-images.githubusercontent.com/7800734/278456991-30414214-74a0-4c5d-98af-faf2faaa4dae.png)
> 
> and B:  
> 
> ![image](https://user-images.githubusercontent.com/7800734/278457062-d23f4177-de93-4543-93e3-0f93c0049b7a.png)
> 
> So, it seems that both Grobid and PDFPlumber are possibly mistaking the dot of the "i" in the line below as a "." in the line in question. 
>
> And Grobid splits into a new "paragraph" there. but both sentence boxes grab that ".".

---------

Another update to _box_groups_to_span_groups that prevents SpanGroup overlaps of a different type (when MergeSpans merges token spans encompassing already allocated tokens) was also added in. 


----------

Also added a fix for the "missing attribute: 'coords'" that was also contributing to the overall failure rate.

-----------

Ran this on a list of past test PDFs, as well as recently failed PDFs from spp prod logs and they all pass (snippet from jupyter notebook includes my personal debugging comments...)
```
sha = '74da5d99e7d951f0dc9c3111186b22544a18bff5' # spangroups overlapping at paragraphs -- passes!
sha = '43659b55f75e3b2ea626bfc8eeea80afa3798c97' # spangroups overlapping at sections -- passes!
sha = 'ade545fda5015a8aac957a69a126da55451ff016' # spangroups overlapping at sections -- passes!
sha = '59e4c0ecfdcbaa651ca2c40625817bb83a9af4c3' # spangroups overlapping at sections -- passes!
sha = '3d5c8c04f42be8bc2fd6038e6f4099bbcfaa0c54' # overlap at (27919, 28096, 9), (27952, 27953, 10) -- passes!
sha = '1d1d7702cc4aaa3f66c29d4eb5ac023091d601e0' # this one's effed up no paragraphs -- successful but no sentences YET does have mentions ??? -- passes!!!!

sha = '121e30c48546e671dc5e16c694c5e69b392cf8fb' # OG experimental paper (3 pager), wondering if takase et al ref is part of sentence... should be! -- yep, it is. Passes!!
sha = 'e5910c027af0ee9c1901c57f6579d903aedee7f4' # test paper for test_grobid_augment_existing...

# sha = '32ff296b592d9cb69c88e239c8e80c7cc5cb3207' # this one has weird stuff for in-between text deciphering -- passes though!
# sha = '2423065e82ffbeb15353517cd8ceed9b168f039d' # a successful one -- has nothing of the sort (GOOD) -- still works after sections refactor! -- great
# sha = 'd55e9255deeb98ca2db55cd2e9bfac22774a2c32' # messed up weird mention not found in section -- 
# sha = '7535981e48c5cccd4d101895b2a350f114d25f5f' # ok maybe better same as above
# sha = 'b936dc63ad9a1380537b0bcc889c92b6af00431e' # sentence doesn't have coords? let's see... -- passes!
# sha = '6ae0afceaaa55ac6d4ec9b5b321f9aa1334b0429' # coords.. -- passes
# sha = '0706021a12b2d74eb5f9fd2f5dc187581a8c66a5' # i jus wanna see "after discussing the risks and benefits" section if 30 is there
# sha = '63929df1d44cec7b407d063f222fcc64e3de2ad3' # dikken et al 2012 section 0 -- only 2012 is there  --- is it the mention? or the section sentence? -- NOICE. added pad_x on sentences
# sha = '51c96902345101a9f2108749ad96d869e595548d' # is it the same in grobid xml, missing numbers/years? of refs?
# sha = '6bb4b89a1dd3bb03a3a2523a2e7867c1bb73a52a' # i jus wana picture -- no i also want grobid boxes drawn (BAD)
# sha = '304e2a42e897aa728d394e2d1e60ea26f4f1c101' # is abstract just ","?? -- no.
# sha = '8dd9ac4f26bee54cf1ee85c50fd63a1f44555fd1' # let's see a recently failed one -- WORKS!! IRL it's a straight up UGLY PDF.
# sha = '2c7f2e6f481873f72c9477e6d5447d1715668da6' 
# sha = 'dfbd16a81af6763d77696a620263295c2ea230f4'
# sha = 'b1e7e7df5aa502a2922ede6325e9aae2f14f6b71'
# sha = '383cfcef25477da08c86f96f5abcd7f796a1b51e'
# sha = '8a408271a1a2226163a579499905a0f4752b5085'
# sha = 'd5be1893584b41f6b567a6ac1a4d7676d80b0b98' # works! previously failed? i think?
```

---------
TODO: 
- [ ] update mmda version in spp-grobid-api