### PR TITLE
grobid augmenter - fix Sections-Paragraphs bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.9.16'
+version = '0.9.17'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/src/mmda/parsers/grobid_augment_existing_document_parser.py
+++ b/src/mmda/parsers/grobid_augment_existing_document_parser.py
@@ -139,13 +139,15 @@ class GrobidAugmentExistingDocumentParser(Parser):
                     unallocated_tokens_dict=unallocated_section_tokens_dict,
                     fix_overlaps=True,
                     ) 
+                # check that conversion to spangroups resulted in actual spans before adding them to the section
                 if all([sg.spans for sg in this_paragraph_sentence_span_groups]):
                     sentence_span_groups.extend(this_paragraph_sentence_span_groups)
-                paragraph_spans = []
-                for sg in this_paragraph_sentence_span_groups:
-                    paragraph_spans.extend(sg.spans)
-                # TODO add boxes to paragraph spangroups
-                this_section_paragraph_span_groups.append(SpanGroup(spans=paragraph_spans))
+                    paragraph_spans = []
+                    for sg in this_paragraph_sentence_span_groups:
+                        paragraph_spans.extend(sg.spans)
+                    # TODO add boxes to paragraph spangroups
+                    this_section_paragraph_span_groups.append(SpanGroup(spans=paragraph_spans))
+                    
             paragraph_span_groups.extend(this_section_paragraph_span_groups)
             for sg in this_section_paragraph_span_groups:
                 section_spans.extend(sg.spans)


### PR DESCRIPTION
For https://github.com/allenai/scholar/issues/38452 and https://github.com/allenai/scholar/issues/39910
 
This fixes a bug that was resulting in sections that had paragraphs but no sentences, which resulted in an error in pipeline-elements in SPP.

**then** (from initial investigation notes in https://github.com/allenai/scholar/issues/38452#issuecomment-1821935080) -- section id 4 has a paragraph but no sentences (paragraphs come from sentences so this didn't make sense):
![image](https://github.com/allenai/scholar/assets/7800734/04b96d59-a1ac-4588-af2c-5dc1436f774f)

The problem was in the python control flow where paragraphs were being added to even if we weren't adding the sentences (due to the sentence text already being claimed by the previous duplicate section -- due to it being a weird PDF and Grobid giving double sections -- more details on that under "continued investigation notes 11/29:" in the same investigation notes comment linked above)

**now** -- no empty paragraph/sentence-less section!

![image](https://github.com/allenai/mmda/assets/7800734/f263c08b-943b-4b7b-a09c-32622f8ba9dc)

todo:
- [ ] update mmda version in spp-grobid-api
- [ ] redrive and confirm successes
- [ ] check off the boxes here: https://github.com/allenai/scholar/issues/38452#issuecomment-1830672075
