### PR TITLE
bump pydantic to v2 for all packages.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
         'pdfplumber==0.7.4',
         'requests',
         'pandas<2',
-        'pydantic[settings]>=1,<3',
+        'pydantic>=1,<3',
+        'pydantic-settings>=2.0',
         'ncls==0.0.66',
         'necessary>=0.3.2',
 ]
@@ -74,14 +75,16 @@ pysbd_predictors = [
 ]
 heuristic_predictors = [
     'tokenizers',
-    'pydantic>=1,<2',
+    'pydantic>=1,<3',
+    'pydantic-settings>=2.0',
 ]
 lp_predictors = [
     'layoutparser',
     'torch',
     'torchvision',
     'effdet',
-    'pydantic>=1,<2'
+    'pydantic>=1,<3',
+    'pydantic-settings>=2.0',
 ]
 hf_predictors = [
     'torch',
@@ -91,38 +94,44 @@ hf_predictors = [
 vila_predictors = [
     'vila>=0.5,<0.6',
     'transformers<4.34.0',
-    'pydantic>=1,<2',
+    'pydantic>=1,<3',
+    'pydantic-settings>=2.0',
 ]
 mention_predictor = [
     'transformers[torch]',
     'optimum[onnxruntime]',
-    'pydantic>=1,<2',
+    'pydantic>=1,<3',
+    'pydantic-settings>=2.0',
 ]
 mention_predictor_gpu = [
     'transformers[torch]',
     'optimum[onnxruntime-gpu]',
-    'pydantic>=1,<2',
+    'pydantic>=1,<3',
+    'pydantic-settings>=2.0',
 ]
 bibentry_predictor = [
     'transformers',
     'unidecode',
     'torch',
     'optimum[onnxruntime]',
-    'pydantic>=1,<2',
+    'pydantic>=1,<3',
+    'pydantic-settings>=2.0',
 ]
 bibentry_predictor_gpu = [
     'transformers',
     'unidecode',
     'torch',
     'optimum[onnxruntime-gpu]',
-    'pydantic>=1,<2'
+    'pydantic>=1,<3',
+    'pydantic-settings>=2.0',
 ]
 bibentry_detection_predictor = [
     'Pillow<10',
     'layoutparser',
     'torch==1.8.0+cu111',
     'torchvision==0.9.0+cu111',
-    'pydantic<=1,<2',
+    'pydantic>=1,<3',
+    'pydantic-settings>=2.0',
 ]
 citation_links = [
     'numpy',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,15 +9,16 @@ license = {text = 'Apache-2.0'}
 readme = 'README.md'
 requires-python = '>=3.7'
 dependencies = [
-        'tqdm',
-        'pdf2image',
-        'pdfplumber==0.7.4',
-        'requests',
-        'pandas<2',
-        'pydantic>=1,<3',
-        'pydantic-settings>=2.0',
-        'ncls==0.0.66',
-        'necessary>=0.3.2',
+      'tqdm',
+      'pdf2image',
+      'pdfplumber==0.7.4',
+      'requests',
+      'pandas<2',
+      'pydantic>=1,<3',
+      'pydantic-settings>=2.0',
+      'ncls==0.0.66',
+      'necessary>=0.3.2',
+      'numpy<2'
 ]
 
 [project.urls]
@@ -99,13 +100,13 @@ vila_predictors = [
 ]
 mention_predictor = [
     'transformers[torch]',
-    'optimum[onnxruntime]',
+    'optimum[onnxruntime]<1.14',
     'pydantic>=1,<3',
     'pydantic-settings>=2.0',
 ]
 mention_predictor_gpu = [
     'transformers[torch]',
-    'optimum[onnxruntime-gpu]',
+    'optimum[onnxruntime-gpu]<1.14',
     'pydantic>=1,<3',
     'pydantic-settings>=2.0',
 ]
@@ -113,7 +114,7 @@ bibentry_predictor = [
     'transformers',
     'unidecode',
     'torch',
-    'optimum[onnxruntime]',
+    'optimum[onnxruntime]<1.14',
     'pydantic>=1,<3',
     'pydantic-settings>=2.0',
 ]
@@ -121,15 +122,23 @@ bibentry_predictor_gpu = [
     'transformers',
     'unidecode',
     'torch',
-    'optimum[onnxruntime-gpu]',
+    'optimum[onnxruntime-gpu]<1.14',
+    'pydantic>=1,<3',
+    'pydantic-settings>=2.0',
+]
+bibentry_detection_predictor_gpu = [
+    'Pillow<10',
+    'layoutparser',
+    'torch',
+    'torchvision',
     'pydantic>=1,<3',
     'pydantic-settings>=2.0',
 ]
 bibentry_detection_predictor = [
     'Pillow<10',
     'layoutparser',
-    'torch==1.8.0+cu111',
-    'torchvision==0.9.0+cu111',
+    'torch',
+    'torchvision',
     'pydantic>=1,<3',
     'pydantic-settings>=2.0',
 ]
@@ -138,7 +147,7 @@ citation_links = [
     'thefuzz[speedup]',
     'scikit-learn',
     'xgboost',
-    'pydantic>=1,<2',
+    'pydantic>=1,<3',
 ]
 section_nesting = [
     'numpy',
@@ -147,14 +156,14 @@ section_nesting = [
 ]
 figure_table_predictors = [
     'scipy',
-    'pydantic>=1,<2',
+    'pydantic>=1,<3',
 ]
 svm_word_predictor = [
     'scikit-learn',
     'scipy',
     'numpy',
     'tokenizers',
-    'pydantic>=1,<2',
+    'pydantic>=1,<3',
 ]
 recipes = [
     'layoutparser',

--- a/src/ai2_internal/api.py
+++ b/src/ai2_internal/api.py
@@ -1,6 +1,6 @@
 from typing import Any, List, Optional, Type
 
-from pydantic import BaseModel, Extra, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 import mmda.types.annotation as mmda_ann
 
@@ -64,10 +64,11 @@ class Attributes(BaseModel):
         return cls(**metadata.to_json())
 
     def to_mmda(self) -> mmda_ann.Metadata:
-        return mmda_ann.Metadata.from_json(self.dict())
+        return mmda_ann.Metadata.from_json(self.model_dump())
 
 
-class Annotation(BaseModel, extra=Extra.ignore):
+class Annotation(BaseModel):
+    model_config = ConfigDict(extra='ignore')
     attributes: Attributes = Attributes()
 
     @classmethod
@@ -103,7 +104,7 @@ class BoxGroup(Annotation):
         )
 
     def to_mmda(self) -> mmda_ann.BoxGroup:
-        metadata = mmda_ann.Metadata.from_json(self.attributes.dict())
+        metadata = mmda_ann.Metadata.from_json(self.attributes.model_dump())
         if self.type:
             metadata.type=self.type
         return mmda_ann.BoxGroup(
@@ -153,7 +154,7 @@ class SpanGroup(Annotation):
         return ret
 
     def to_mmda(self) -> mmda_ann.SpanGroup:
-        metadata = mmda_ann.Metadata.from_json(self.attributes.dict())
+        metadata = mmda_ann.Metadata.from_json(self.attributes.model_dump())
         if self.type:
             metadata.type = self.type
         if self.text:

--- a/src/ai2_internal/bibentry_detection_predictor/interface.py
+++ b/src/ai2_internal/bibentry_detection_predictor/interface.py
@@ -8,7 +8,8 @@ as a definition of the objects it expects, and those it returns.
 
 from typing import List
 
-from pydantic import BaseModel, BaseSettings, Field
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
 
 from ai2_internal import api
 from mmda.predictors.d2_predictors.bibentry_detection_predictor import BibEntryDetectionPredictor

--- a/src/ai2_internal/bibentry_predictor/interface.py
+++ b/src/ai2_internal/bibentry_predictor/interface.py
@@ -8,7 +8,8 @@ as a definition of the objects it expects, and those it returns.
 
 from typing import List, Optional
 
-from pydantic import BaseModel, BaseSettings, Field
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
 
 from mmda.predictors.hf_predictors.bibentry_predictor.predictor import BibEntryPredictor
 

--- a/src/ai2_internal/bibentry_predictor_mmda/interface.py
+++ b/src/ai2_internal/bibentry_predictor_mmda/interface.py
@@ -8,7 +8,8 @@ as a definition of the objects it expects, and those it returns.
 
 from typing import List
 
-from pydantic import BaseModel, BaseSettings, Field
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
 
 from ai2_internal import api
 from mmda.predictors.hf_predictors.bibentry_predictor.predictor import BibEntryPredictor

--- a/src/ai2_internal/citation_links/interface.py
+++ b/src/ai2_internal/citation_links/interface.py
@@ -8,7 +8,8 @@ as a definition of the objects it expects, and those it returns.
 
 from typing import List, Tuple
 
-from pydantic import BaseModel, BaseSettings, Field
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
 
 from ai2_internal import api
 from mmda.predictors.xgb_predictors.citation_link_predictor import CitationLinkPredictor

--- a/src/ai2_internal/citation_mentions/interface.py
+++ b/src/ai2_internal/citation_mentions/interface.py
@@ -10,7 +10,8 @@ from typing import List
 from itertools import groupby
 from bisect import bisect
 
-from pydantic import BaseModel, BaseSettings
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings
 
 from ai2_internal import api
 from mmda.predictors.hf_predictors.mention_predictor import MentionPredictor

--- a/src/ai2_internal/dwp_heuristic/interface.py
+++ b/src/ai2_internal/dwp_heuristic/interface.py
@@ -1,6 +1,7 @@
 from typing import List
 
-from pydantic import BaseModel, BaseSettings, Field
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
 
 from ai2_internal.api import SpanGroup
 from mmda.predictors.heuristic_predictors.dictionary_word_predictor import (

--- a/src/ai2_internal/figure_table_predictors/interface.py
+++ b/src/ai2_internal/figure_table_predictors/interface.py
@@ -8,7 +8,8 @@ as a definition of the objects it expects, and those it returns.
 
 from typing import List
 
-from pydantic import BaseModel, BaseSettings
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings
 
 from mmda.predictors.heuristic_predictors.figure_table_predictors import FigureTablePredictions
 from mmda.types.document import Document

--- a/src/ai2_internal/layout_parser/interface.py
+++ b/src/ai2_internal/layout_parser/interface.py
@@ -10,7 +10,8 @@ import logging
 from typing import List
 
 import torch
-from pydantic import BaseModel, BaseSettings, Field
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
 
 from ai2_internal.api import BoxGroup
 from mmda.predictors.lp_predictors import LayoutParserPredictor

--- a/src/ai2_internal/svm_word_predictor/interface.py
+++ b/src/ai2_internal/svm_word_predictor/interface.py
@@ -1,6 +1,7 @@
 from typing import List
 
-from pydantic import BaseModel, BaseSettings, Field
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
 
 from ai2_internal.api import SpanGroup
 from mmda.predictors.sklearn_predictors.svm_word_predictor import SVMWordPredictor

--- a/src/ai2_internal/vila/interface.py
+++ b/src/ai2_internal/vila/interface.py
@@ -10,7 +10,8 @@ import logging
 from typing import List
 
 import torch
-from pydantic import BaseModel, BaseSettings, Field
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings
 
 from ai2_internal import api
 from mmda.predictors.hf_predictors.token_classification_predictor import (


### PR DESCRIPTION
I'm using this package as a dependency for another project, but can't install it until the pydantic dependency is bumped to v2 and the `bibentry_detection_predictor` section is broken out into two groups: one for cpu and one for gpu.

Additionally, the weights in `s3` are built using `numpy < 2`, so the C interface is not compatible with version 2. We would need to retrain the model to make it compatible with version 2.