### PR TITLE
Migrate to Python 3.11 for TIMO services

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'mmda'
-version = '0.9.18'
+version = '0.9.19'
 description = 'MMDA - multimodal document analysis'
 authors = [
     {name = 'Allen Institute for Artificial Intelligence', email = 'contact@allenai.org'},

--- a/src/ai2_internal/config.yaml
+++ b/src/ai2_internal/config.yaml
@@ -51,7 +51,7 @@ model_variants:
     extras_require: ["dev", "lp_predictors"]
 
     # Version of python required for model runtime, e.g. 3.7, 3.8, 3.9
-    python_version: 3.8
+    python_version: "3.11"
 
     # Whether this model supports CUDA GPU acceleration
     cuda: True
@@ -125,7 +125,7 @@ model_variants:
     artifacts_s3_path: s3://ai2-timo-registry/model-artifacts/bibentryparser/v0.onnx.tar.gz
 
     # Version of python required for model runtime, e.g. 3.7, 3.8, 3.9
-    python_version: 3.8
+    python_version: "3.11"
 
     # Whether this model supports CUDA GPU acceleration
     cuda: True
@@ -163,7 +163,7 @@ model_variants:
     artifacts_s3_path: s3://ai2-s2-mmda/models/citation-mentions/2022-07-27-minilm-10k/model/artifacts-onnx16.tar.gz
 
     # Version of python required for model runtime
-    python_version: "3.8"
+    python_version: "3.11"
 
     # Whether this model supports CUDA GPU acceleration
     cuda: True
@@ -305,7 +305,7 @@ model_variants:
     artifacts_s3_path: null
 
     # Version of python required for model runtime, e.g. 3.7, 3.8, 3.9
-    python_version: 3.8
+    python_version: "3.11"
 
     # Whether this model supports CUDA GPU acceleration
     cuda: false

--- a/src/ai2_internal/config.yaml
+++ b/src/ai2_internal/config.yaml
@@ -346,7 +346,7 @@ model_variants:
     artifacts_s3_path: s3://ai2-timo-registry/model-artifacts/svm-word-predictor/v0.tar.gz
 
     # Version of python required for model runtime, e.g. 3.7, 3.8, 3.9
-    python_version: "3.10"
+    python_version: "3.11"
 
     # Whether this model supports CUDA GPU acceleration
     cuda: false


### PR DESCRIPTION
## Summary
Migrates five TIMO model configurations from Python 3.8/3.10 to Python 3.11 to resolve compatibility issues with modern pip and build tools.

## Changes
- Update `python_version` in `src/ai2_internal/config.yaml` to "3.11" for variants:
  - `layout_parser` (3.8 → 3.11, fixes layout-parser-v0 service)
  - `bibentry_predictor_mmda` (3.8 → 3.11)
  - `citation_mentions` (3.8 → 3.11)
  - `dwp-heuristic` (3.8 → 3.11)
  - `svm-word-predictor` (3.10 → 3.11)
- Bump package version from 0.9.18 to 0.9.19 in `pyproject.toml`

## Context
This is part of the migration effort to resolve Python 3.8 compatibility issues documented in https://github.com/allenai/scholar/issues/41682. Python 3.8 is no longer supported by modern pip installers (requires 3.9+), causing TIMO service build failures.

**Critical**: The `layout-parser-v0` service is experiencing high latency issues (p50 > 120s) which may be related to the failed builds and outdated Python version.

**Why Python 3.11?**
- Better performance (10-60% faster than 3.8)
- Longer support lifecycle (security updates until October 2027)
- Modern language features and improved error messages
- Already supported by TIMO infrastructure (min version is 3.8)

## Testing
- [ ] Verify package builds with Python 3.11
- [ ] Run integration tests for all five variants
- [ ] Publish config to TIMO registry after merge (version 0.9.19)
- [ ] Update timo-services to reference new version for all five services
- [ ] Deploy and verify all services, prioritizing layout-parser-v0

## Related Services
- layout-parser-v0 (HIGH PRIORITY)
- citation_mentions_v0
- bibentry-predictor-mmda-v0
- dwp-v1
- word-predictor-v1

🤖 Generated with Claude Code